### PR TITLE
Patch for Text.Pandoc.Builder.simpleTable generating empty tables (Issue 301)

### DIFF
--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -332,4 +332,8 @@ table caption cellspecs headers rows = singleton $
 simpleTable :: [Blocks]   -- ^ Headers
             -> [[Blocks]] -- ^ Rows
             -> Blocks
-simpleTable = table empty []
+simpleTable headers = table empty (mapConst defaults headers) headers
+  where defaults = (AlignDefault, 0)
+
+mapConst :: Functor f => b -> f a -> f b
+mapConst = fmap . const


### PR DESCRIPTION
Tables created by `simpleTable` seem to render with all their cells blank (see [Issue 301](http://code.google.com/p/pandoc/issues/detail?id=301)).  That seems to be because `simpleTable` passes an empty list of (alignment, cellwidth) pairs: this change replaces that with a list of defaults, of the same length as the headers list.
