### PR TITLE
Building on 7.4.1 on OS X Lion reports an ambiguity in the use of (<>)

### DIFF
--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -137,7 +137,7 @@ module Text.Pandoc.Builder ( module Text.Pandoc.Definition
 where
 import Text.Pandoc.Definition
 import Data.String
-import Data.Monoid
+import Data.Monoid ((<>))
 import Data.Maybe (fromMaybe)
 import Data.Sequence (Seq, (|>), viewr, viewl, ViewR(..), ViewL(..))
 import qualified Data.Sequence as Seq


### PR DESCRIPTION
This hides the unnecessary occurrence in Monoid.
