### PR TITLE
relax cabal constraint for aeson

### DIFF
--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -46,5 +46,5 @@ Library
                      syb >= 0.1 && < 0.5,
                      ghc-prim >= 0.2,
                      bytestring >= 0.9 && < 0.11,
-                     aeson >= 0.6.2 && < 0.8,
+                     aeson >= 0.6.2 && < 0.9,
                      deepseq-generics >= 0.1 && < 0.2


### PR DESCRIPTION
[`aeson-0.8.0.0`](https://hackage.haskell.org/package/aeson-0.8.0.0) has been released.
This PR makes relax cabal constraint for aeson.

``` log
< 0.8 ->
< 0.9
```
