### PR TITLE
Bump aeson upper version bounds

### DIFF
--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -46,5 +46,5 @@ Library
                      syb >= 0.1 && < 0.5,
                      ghc-prim >= 0.2,
                      bytestring >= 0.9 && < 0.11,
-                     aeson >= 0.6.2 && < 0.9,
+                     aeson >= 0.6.2 && < 0.10,
                      deepseq-generics >= 0.1 && < 0.2


### PR DESCRIPTION
Allow `pandoc-types` to build with the latest version of `aeson` (0.9.0.1).

Note that [`pandoc` itself](https://github.com/jgm/pandoc/blob/d9e5d9fe068931a7244a6b72e33c4a7dbacbe7ef/pandoc.cabal#L262) also has an out-of-date `aeson` dependency.