### PR TITLE
Use `<$` instead of `fmap . const`

### DIFF
--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -178,6 +178,7 @@ import Data.Typeable
 import Data.Traversable
 import Control.Arrow ((***))
 import GHC.Generics (Generic)
+import Data.Functor ((<$))
 
 #if MIN_VERSION_base(4,5,0)
 -- (<>) is defined in Data.Monoid

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -483,12 +483,8 @@ table caption cellspecs headers rows = singleton $
 simpleTable :: [Blocks]   -- ^ Headers
             -> [[Blocks]] -- ^ Rows
             -> Blocks
-simpleTable headers = table mempty (mapConst defaults headers) headers
+simpleTable headers = table mempty (defaults <$ headers) headers
   where defaults = (AlignDefault, 0)
 
 divWith :: Attr -> Blocks -> Blocks
 divWith attr = singleton . Div attr . toList
-
-mapConst :: Functor f => b -> f a -> f b
-mapConst = fmap . const
-


### PR DESCRIPTION
Not sure if this will work with old Preludes but let's run the Travis tests and see...