### PR TITLE
Reimplement ToJSON / FromJSON instances, and update format

### DIFF
--- a/Text/Pandoc/Arbitrary.hs
+++ b/Text/Pandoc/Arbitrary.hs
@@ -1,0 +1,191 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, ScopedTypeVariables #-}
+-- provides Arbitrary instance for Pandoc types
+module Text.Pandoc.Arbitrary ()
+where
+import Test.QuickCheck 
+import Control.Monad (liftM, liftM2)
+import Text.Pandoc.Definition
+import Text.Pandoc.Builder
+
+realString :: Gen String
+realString = resize 8 $ listOf $ frequency [ (9, elements [' '..'\127'])
+                                           , (1, elements ['\128'..'\9999']) ]
+
+arbAttr :: Gen Attr
+arbAttr = do
+  id' <- elements ["","loc"]
+  classes <- elements [[],["haskell"],["c","numberLines"]]
+  keyvals <- elements [[],[("start","22")],[("a","11"),("b_2","a b c")]]
+  return (id',classes,keyvals)
+
+instance Arbitrary Inlines where
+  arbitrary = liftM (fromList :: [Inline] -> Inlines) arbitrary
+
+instance Arbitrary Blocks where
+  arbitrary = liftM (fromList :: [Block] -> Blocks) arbitrary
+
+instance Arbitrary Inline where
+  arbitrary = resize 3 $ arbInline 2
+
+arbInlines :: Int -> Gen [Inline]
+arbInlines n = listOf1 (arbInline n) `suchThat` (not . startsWithSpace)
+  where startsWithSpace (Space:_) = True
+        startsWithSpace        _  = False
+
+-- restrict to 3 levels of nesting max; otherwise we get
+-- bogged down in indefinitely large structures
+arbInline :: Int -> Gen Inline
+arbInline n = frequency $ [ (60, liftM Str realString)
+                          , (60, return Space)
+                          , (10, liftM2 Code arbAttr realString)
+                          , (5,  elements [ RawInline (Format "html") "<a id=\"eek\">"
+                                          , RawInline (Format "latex") "\\my{command}" ])
+                          ] ++ [ x | x <- nesters, n > 1]
+   where nesters = [ (10,  liftM Emph $ arbInlines (n-1))
+                   , (10,  liftM Strong $ arbInlines (n-1))
+                   , (10,  liftM Strikeout $ arbInlines (n-1))
+                   , (10,  liftM Superscript $ arbInlines (n-1))
+                   , (10,  liftM Subscript $ arbInlines (n-1))
+                   , (10,  liftM SmallCaps $ arbInlines (n-1))
+                   , (10,  do x1 <- arbitrary
+                              x2 <- arbInlines (n-1)
+                              return $ Quoted x1 x2)
+                   , (10,  do x1 <- arbitrary
+                              x2 <- realString
+                              return $ Math x1 x2)
+                   , (10,  do x0 <- arbAttr
+                              x1 <- arbInlines (n-1)
+                              x3 <- realString
+                              x2 <- realString
+                              return $ Link x0 x1 (x2,x3))
+                   , (10,  do x0 <- arbAttr
+                              x1 <- arbInlines (n-1)
+                              x3 <- realString
+                              x2 <- realString
+                              return $ Image x0 x1 (x2,x3))
+                   , (2,  liftM2 Cite arbitrary (arbInlines 1))
+                   , (2,  liftM Note $ resize 3 $ listOf1 $ arbBlock (n-1))
+                   ]
+
+instance Arbitrary Block where
+  arbitrary = resize 3 $ arbBlock 2
+
+arbBlock :: Int -> Gen Block
+arbBlock n = frequency $ [ (10, liftM Plain $ arbInlines (n-1))
+                         , (15, liftM Para $ arbInlines (n-1))
+                         , (5,  liftM2 CodeBlock arbAttr realString)
+                         , (2,  elements [ RawBlock (Format "html")
+                                            "<div>\n*&amp;*\n</div>"
+                                         , RawBlock (Format "latex")
+                                            "\\begin[opt]{env}\nhi\n{\\end{env}"
+                                         ])
+                         , (5,  do x1 <- choose (1 :: Int, 6)
+                                   x2 <- arbInlines (n-1)
+                                   return (Header x1 nullAttr x2))
+                         , (2, return HorizontalRule)
+                         ] ++ [x | x <- nesters, n > 0]
+   where nesters = [ (5,  liftM BlockQuote $ listOf1 $ arbBlock (n-1))
+                   , (5,  do x2 <- arbitrary
+                             x3 <- arbitrary
+                             x1 <- arbitrary `suchThat` (> 0)
+                             x4 <- listOf1 $ listOf1 $ arbBlock (n-1)
+                             return $ OrderedList (x1,x2,x3) x4 )
+                   , (5,  liftM BulletList $ (listOf1 $ listOf1 $ arbBlock (n-1)))
+                   , (5,  do items <- listOf1 $ do
+                                        x1 <- listOf1 $ listOf1 $ arbBlock (n-1)
+                                        x2 <- arbInlines (n-1)
+                                        return (x2,x1)
+                             return $ DefinitionList items)
+                   , (2, do rs <- choose (1 :: Int, 4)
+                            cs <- choose (1 :: Int, 4)
+                            x1 <- arbInlines (n-1)
+                            x2 <- vector cs
+                            x3 <- vectorOf cs $ elements [0, 0.25]
+                            x4 <- vectorOf cs $ listOf $ arbBlock (n-1)
+                            x5 <- vectorOf rs $ vectorOf cs
+                                  $ listOf $ arbBlock (n-1)
+                            return (Table x1 x2 x3 x4 x5))
+                   ]
+
+instance Arbitrary Pandoc where
+        arbitrary = resize 8 $ liftM2 Pandoc arbitrary arbitrary
+
+instance Arbitrary CitationMode where
+        arbitrary
+          = do x <- choose (0 :: Int, 2)
+               case x of
+                   0 -> return AuthorInText
+                   1 -> return SuppressAuthor
+                   2 -> return NormalCitation
+                   _ -> error "FATAL ERROR: Arbitrary instance, logic bug"
+
+instance Arbitrary Citation where
+        arbitrary
+          = do x1 <- listOf $ elements $ ['a'..'z'] ++ ['0'..'9'] ++ ['_']
+               x2 <- arbInlines 1
+               x3 <- arbInlines 1
+               x4 <- arbitrary
+               x5 <- arbitrary
+               x6 <- arbitrary
+               return (Citation x1 x2 x3 x4 x5 x6)
+
+instance Arbitrary MathType where
+        arbitrary
+          = do x <- choose (0 :: Int, 1)
+               case x of
+                   0 -> return DisplayMath
+                   1 -> return InlineMath
+                   _ -> error "FATAL ERROR: Arbitrary instance, logic bug"
+
+instance Arbitrary QuoteType where
+        arbitrary
+          = do x <- choose (0 :: Int, 1)
+               case x of
+                   0 -> return SingleQuote
+                   1 -> return DoubleQuote
+                   _ -> error "FATAL ERROR: Arbitrary instance, logic bug"
+
+instance Arbitrary Meta where
+        arbitrary
+          = do (x1 :: Inlines) <- arbitrary
+               (x2 :: [Inlines]) <- liftM (filter (not . isNull)) arbitrary
+               (x3 :: Inlines) <- arbitrary
+               return $ setMeta "title" x1
+                      $ setMeta "author" x2
+                      $ setMeta "date" x3
+                      $ nullMeta
+
+instance Arbitrary Alignment where
+        arbitrary
+          = do x <- choose (0 :: Int, 3)
+               case x of
+                   0 -> return AlignLeft
+                   1 -> return AlignRight
+                   2 -> return AlignCenter
+                   3 -> return AlignDefault
+                   _ -> error "FATAL ERROR: Arbitrary instance, logic bug"
+
+instance Arbitrary ListNumberStyle where
+        arbitrary
+          = do x <- choose (0 :: Int, 6)
+               case x of
+                   0 -> return DefaultStyle
+                   1 -> return Example
+                   2 -> return Decimal
+                   3 -> return LowerRoman
+                   4 -> return UpperRoman
+                   5 -> return LowerAlpha
+                   6 -> return UpperAlpha
+                   _ -> error "FATAL ERROR: Arbitrary instance, logic bug"
+
+instance Arbitrary ListNumberDelim where
+        arbitrary
+          = do x <- choose (0 :: Int, 3)
+               case x of
+                   0 -> return DefaultDelim
+                   1 -> return Period
+                   2 -> return OneParen
+                   3 -> return TwoParens
+                   _ -> error "FATAL ERROR: Arbitrary instance, logic bug"
+

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -77,7 +77,7 @@ module Text.Pandoc.Definition ( Pandoc(..)
 
 import Data.Generics (Data, Typeable)
 import Data.Ord (comparing)
-import Data.Aeson
+import Data.Aeson hiding (Null)
 import qualified Data.Aeson.Types as Aeson
 import Control.Monad (guard)
 import qualified Data.Map as M
@@ -370,13 +370,30 @@ instance ToJSON MathType where
   
 instance FromJSON ListNumberStyle
   where parseJSON = parseJSON'
-instance ToJSON ListNumberStyle
-  where toJSON = toJSON'
+instance ToJSON ListNumberStyle where
+  toJSON lsty = object [ "t" .= String s
+                       , "c" .= Aeson.emptyArray
+                       ]
+    where s = case lsty of
+            DefaultStyle -> "DefaultStyle"
+            Example      -> "Example"
+            Decimal      -> "Decimal"
+            LowerRoman   -> "LowerRoman"
+            UpperRoman   -> "UpperRoman"
+            LowerAlpha   -> "LowerAlpha"
+            UpperAlpha   -> "UpperAlpha"
 
 instance FromJSON ListNumberDelim
   where parseJSON = parseJSON'
-instance ToJSON ListNumberDelim
-  where toJSON = toJSON'
+instance ToJSON ListNumberDelim where
+  toJSON delim = object [ "t" .= String s
+                        , "c" .= Aeson.emptyArray
+                        ]
+    where s = case delim of
+            DefaultDelim -> "DefaultDelim"
+            Period       -> "Period"
+            OneParen     -> "OneParen"
+            TwoParens    -> "TwoParens"
 
 instance FromJSON Alignment
   where parseJSON = parseJSON'
@@ -485,8 +502,74 @@ instance ToJSON Inline where
 
 instance FromJSON Block
   where parseJSON = parseJSON'
-instance ToJSON Block
-  where toJSON = toJSON'
+instance ToJSON Block where
+  toJSON (Plain ils) =
+    object [ "t" .= String "Plain"
+           , "c" .= ils
+           ]
+  toJSON (Para ils) =
+    object [ "t" .= String "Para"
+           , "c" .= ils
+           ]
+  toJSON (CodeBlock attr s) =
+    object [ "t" .= String "CodeBlock"
+           , "c" .= Array [ toJSON attr
+                          , toJSON s
+                          ]
+           ]
+  toJSON (RawBlock fmt s) =
+    object [ "t" .= String "RawBlock"
+           , "c" .= Array [ toJSON fmt
+                          , toJSON s
+                          ]
+           ]
+  toJSON (BlockQuote blks) =
+    object [ "t" .= String "BlockQuote"
+           , "c" .= blks
+           ]
+
+  toJSON (OrderedList listAttrs blksList) =
+    object [ "t" .= String "OrderedList"
+           , "c" .= Array [ toJSON listAttrs
+                          , toJSON blksList
+                          ]
+           ]
+  toJSON (BulletList blksList) =
+    object [ "t" .= String "BulletList"
+           , "c" .= blksList
+           ]
+  toJSON (DefinitionList defs) =
+    object [ "t" .= String "DefinitionList"
+           , "c" .= defs
+           ]
+  toJSON (Header n attr ils) =
+    object [ "t" .= String "Header"
+           , "c" .= Array [ toJSON n
+                          , toJSON attr
+                          , toJSON ils
+                          ]
+           ]
+  toJSON HorizontalRule =
+    object [ "t" .= String "HorizontalRule"
+           , "c" .= Aeson.emptyArray
+           ]
+  toJSON (Table caption aligns widths cells rows) =
+    object [ "t" .= String "Table"
+           , "c" .= Array [ toJSON caption
+                          , toJSON aligns
+                          , toJSON widths
+                          , toJSON cells
+                          , toJSON rows
+                          ]
+           ]
+  toJSON (Div attr blks) =
+    object [ "t" .= String "Div"
+           , "c" .= blks
+           ]
+  toJSON Null =
+    object [ "t" .= String "Null"
+           , "c" .= Aeson.emptyArray
+           ]
 
 instance FromJSON Pandoc
   where parseJSON = parseJSON'

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -687,11 +687,11 @@ instance FromJSON Pandoc where
                      , x == x'
                      , y == y' -> Pandoc <$> v .: "meta" <*> v .: "blocks"
                      | otherwise ->
-                         fail $ unlines [ "Incompatible API versions: "
+                         fail $ mconcat [ "Incompatible API versions: "
                                         , "encoded with "
                                         , show jVersion
                                         , " but attempted to decode with "
-                                        , show pandocTypesVersion
+                                        , show $ versionBranch pandocTypesVersion
                                         , "."
                                         ]
       _ -> fail "JSON missing pandoc-api-version."

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -312,8 +312,18 @@ parseJSON' :: (Generic a, Aeson.GFromJSON (Rep a))
 #endif
 parseJSON' = Aeson.genericParseJSON jsonOpts
 
-instance FromJSON MetaValue
-  where parseJSON = parseJSON'
+instance FromJSON MetaValue where
+  parseJSON (Object v) = do
+    t <- v .: "t"
+    case t of
+      String "MetaMap"     -> MetaMap     <$> (v .: "c")
+      String "MetaList"    -> MetaList    <$> (v .: "c")
+      String "MetaBool"    -> MetaBool    <$> (v .: "c")
+      String "MetaString"  -> MetaString  <$> (v .: "c")
+      String "MetaInlines" -> MetaInlines <$> (v .: "c")
+      String "MetaBlocks"  -> MetaBlocks  <$> (v .: "c")
+      _ -> mempty
+  parseJSON _ = mempty
 instance ToJSON MetaValue where
   toJSON (MetaMap mp) =
     object [ "t" .= String "MetaMap"
@@ -340,13 +350,21 @@ instance ToJSON MetaValue where
            , "c" .= blks
            ]
 
-instance FromJSON Meta
-  where parseJSON = parseJSON'
+instance FromJSON Meta where
+  parseJSON (Object v) = Meta <$> v .: "unMeta"
+  parseJSON _ = mempty
 instance ToJSON Meta where
   toJSON meta = object [ "unMeta" .= unMeta meta ]
 
-instance FromJSON CitationMode
-  where parseJSON = parseJSON'
+instance FromJSON CitationMode where
+  parseJSON (Object v) = do
+    t <- v .: "t"
+    case t of
+      String "AuthorInText"   -> return AuthorInText
+      String "SuppressAuthor" -> return SuppressAuthor
+      String "NormalCitation" -> return NormalCitation
+      _ -> mempty
+  parseJSON _ = mempty
 instance ToJSON CitationMode where
   toJSON cmode =
     object [ "t" .= String s
@@ -358,8 +376,22 @@ instance ToJSON CitationMode where
             NormalCitation -> "NormalCitation"
 
 
-instance FromJSON Citation
-  where parseJSON = parseJSON'
+instance FromJSON Citation where
+  parseJSON (Object v) = do
+    citationId'      <- v .: "citationId"
+    citationPrefix'  <- v .: "citationPrefix"
+    citationSuffix'  <- v .: "citationSuffix"
+    citationMode'    <- v .: "citationMode"
+    citationNoteNum' <- v .: "citationNoteNum"
+    citationHash'    <- v .: "citationHash"
+    return Citation { citationId = citationId'
+                    , citationPrefix = citationPrefix'
+                    , citationSuffix = citationSuffix'
+                    , citationMode = citationMode'
+                    , citationNoteNum = citationNoteNum'
+                    , citationHash = citationHash'
+                    }
+  parseJSON _ = mempty
 instance ToJSON Citation where
   toJSON cit =
     object [ "citationId"      .= citationId cit
@@ -370,8 +402,14 @@ instance ToJSON Citation where
            , "citationHash"    .= citationHash cit
            ]
 
-instance FromJSON QuoteType
-  where parseJSON = parseJSON'
+instance FromJSON QuoteType where
+  parseJSON (Object v) = do
+    t <- v .: "t"
+    case t of
+      String "SingleQuote" -> return SingleQuote
+      String "DoubleQuote" -> return DoubleQuote
+      _                    -> mempty
+  parseJSON _ = mempty      
 instance ToJSON QuoteType where
   toJSON qtype = object [ "t" .= String s
                         , "c" .= Aeson.emptyArray
@@ -381,8 +419,14 @@ instance ToJSON QuoteType where
             DoubleQuote -> "DoubleQuote"
 
 
-instance FromJSON MathType
-  where parseJSON = parseJSON'
+instance FromJSON MathType where
+  parseJSON (Object v) = do
+    t <- v .: "t"
+    case t of
+      String "DisplayMath" -> return DisplayMath
+      String "InlineMath"  -> return InlineMath
+      _                    -> mempty
+  parseJSON _ = mempty      
 instance ToJSON MathType where
   toJSON mtype = object [ "t" .= String s
                         , "c" .= Aeson.emptyArray
@@ -391,8 +435,19 @@ instance ToJSON MathType where
             DisplayMath -> "DisplayMath"
             InlineMath  -> "InlineMath"
   
-instance FromJSON ListNumberStyle
-  where parseJSON = parseJSON'
+instance FromJSON ListNumberStyle where
+  parseJSON (Object v) = do
+    t <- v .: "t"
+    case t of
+      String "DefaultStyle" -> return DefaultStyle
+      String "Example"      -> return Example
+      String "Decimal"      -> return Decimal
+      String "LowerRoman"   -> return LowerRoman
+      String "UpperRoman"   -> return UpperRoman
+      String "LowerAlpha"   -> return LowerAlpha
+      String "UpperAlpha"   -> return UpperAlpha
+      _                     -> mempty
+  parseJSON _ = mempty      
 instance ToJSON ListNumberStyle where
   toJSON lsty = object [ "t" .= String s
                        , "c" .= Aeson.emptyArray
@@ -406,8 +461,16 @@ instance ToJSON ListNumberStyle where
             LowerAlpha   -> "LowerAlpha"
             UpperAlpha   -> "UpperAlpha"
 
-instance FromJSON ListNumberDelim
-  where parseJSON = parseJSON'
+instance FromJSON ListNumberDelim where
+  parseJSON (Object v) = do
+    t <- v .: "t"
+    case t of
+      String "DefaultDelim" -> return DefaultDelim
+      String "Period"       -> return Period
+      String "OneParen"     -> return OneParen
+      String "TwoParens"    -> return TwoParens
+      _                     -> mempty
+  parseJSON _ = mempty      
 instance ToJSON ListNumberDelim where
   toJSON delim = object [ "t" .= String s
                         , "c" .= Aeson.emptyArray
@@ -418,10 +481,25 @@ instance ToJSON ListNumberDelim where
             OneParen     -> "OneParen"
             TwoParens    -> "TwoParens"
 
-instance FromJSON Alignment
-  where parseJSON = parseJSON'
-instance ToJSON Alignment
-  where toJSON = toJSON'
+instance FromJSON Alignment where
+  parseJSON (Object v) = do
+    t <- v .: "t"
+    case t of
+      String "AlignLeft"    -> return AlignLeft
+      String "AlignRight"   -> return AlignRight
+      String "AlignCenter"  -> return AlignCenter
+      String "AlignDefault" -> return AlignDefault
+      _                     -> mempty
+  parseJSON _ = mempty      
+instance ToJSON Alignment where
+  toJSON delim = object [ "t" .= String s
+                        , "c" .= Aeson.emptyArray
+                        ]
+    where s = case delim of
+            AlignLeft    -> "AlignLeft"
+            AlignRight   -> "AlignRight"
+            AlignCenter  -> "AlignCenter"
+            AlignDefault -> "AlignDefault"
 
 instance FromJSON Inline
   where parseJSON = parseJSON'

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings, OverloadedLists, DeriveDataTypeable,
-             DeriveGeneric, FlexibleContexts, GeneralizedNewtypeDeriving,
-             PatternGuards, CPP
-#-}
+DeriveGeneric, FlexibleContexts, GeneralizedNewtypeDeriving, PatternGuards,
+CPP #-}
 
 {-
 Copyright (c) 2006-2016, John MacFarlane

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -683,9 +683,9 @@ instance ToJSON Block where
 
 instance FromJSON Pandoc where
   parseJSON (Object v) = do
-    mbJVersion <- v .:? "pandoc-api-version" :: Aeson.Parser (Maybe Version)
+    mbJVersion <- v .:? "pandoc-api-version" :: Aeson.Parser (Maybe [Int])
     case mbJVersion of
-      Just jVersion  | x : y : _ <- versionBranch jVersion
+      Just jVersion  | x : y : _ <- jVersion
                      , x' : y' : _ <- versionBranch pandocTypesVersion
                      , x == x'
                      , y == y' -> Pandoc <$> v .: "meta" <*> v .: "blocks"
@@ -701,7 +701,7 @@ instance FromJSON Pandoc where
   parseJSON _ = mempty
 instance ToJSON Pandoc where
   toJSON (Pandoc meta blks) =
-    object [ "pandoc-api-version" .= pandocTypesVersion
+    object [ "pandoc-api-version" .= versionBranch pandocTypesVersion
            , "meta"               .= meta
            , "blocks"             .= blks
            ]

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -421,7 +421,7 @@ instance FromJSON ListNumberStyle where
       "UpperRoman"   -> return UpperRoman
       "LowerAlpha"   -> return LowerAlpha
       "UpperAlpha"   -> return UpperAlpha
-      _                     -> mempty
+      _              -> mempty
   parseJSON _ = mempty      
 instance ToJSON ListNumberStyle where
   toJSON lsty = object [ "t" .= String s
@@ -616,7 +616,7 @@ instance FromJSON Block where
       "CodeBlock"      -> do (attr, s) <- v .: "c"
                              return $ CodeBlock attr s
       "RawBlock"       -> do (fmt, s) <- v .: "c"
-                             return $ CodeBlock fmt s
+                             return $ RawBlock fmt s
       "BlockQuote"     -> BlockQuote <$> v .: "c"
       "OrderedList"    -> do (attr, items) <- v .: "c"
                              return $ OrderedList attr items

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -283,34 +283,9 @@ instance Ord Citation where
 data CitationMode = AuthorInText | SuppressAuthor | NormalCitation
                     deriving (Show, Eq, Ord, Read, Typeable, Data, Generic)
 
--- derive generic instances of FromJSON, ToJSON:
 
-jsonOpts :: Aeson.Options
-jsonOpts = Aeson.defaultOptions{
-                          Aeson.fieldLabelModifier = id
-                        , Aeson.constructorTagModifier = id
-                        , Aeson.allNullaryToStringTag = False
-                        , Aeson.omitNothingFields = False
-                        , Aeson.sumEncoding = Aeson.TaggedObject "t" "c"
-                        }
-
-#if MIN_VERSION_aeson(1,0,0)
-toJSON' :: (Generic a, Aeson.GToJSON Aeson.Zero (Rep a))
-        => a -> Aeson.Value
-#else
-toJSON' :: (Generic a, Aeson.GToJSON (Rep a))
-        => a -> Aeson.Value
-#endif
-toJSON' = Aeson.genericToJSON jsonOpts
-
-#if MIN_VERSION_aeson(1,0,0)
-parseJSON' :: (Generic a, Aeson.GFromJSON Aeson.Zero (Rep a))
-           => Aeson.Value -> Aeson.Parser a
-#else
-parseJSON' :: (Generic a, Aeson.GFromJSON (Rep a))
-           => Aeson.Value -> Aeson.Parser a
-#endif
-parseJSON' = Aeson.genericParseJSON jsonOpts
+-- ToJSON/FromJSON instances. We do this by hand instead of deriving
+-- from generics, so we can have more control over the format.
 
 instance FromJSON MetaValue where
   parseJSON (Object v) = do

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -702,10 +702,9 @@ instance ToJSON Block where
            ]
 
 instance FromJSON Pandoc where
-  parseJSON (Object v) = do
-    (meta, blks) <- v .: "c"
+  parseJSON json = do
+    (meta, blks) <- parseJSON json
     return $ Pandoc meta blks
-  parseJSON _ = mempty
 instance ToJSON Pandoc where
   toJSON (Pandoc meta blks) =
     Array [ toJSON meta

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -87,6 +87,7 @@ import Data.Monoid
 #if MIN_VERSION_base(4,8,0)
 import Control.DeepSeq
 #else
+import Control.Applicative ((<$>), (<*>))
 import Control.DeepSeq.Generics
 #endif
 import Paths_pandoc_types (version)

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -344,9 +344,7 @@ instance FromJSON CitationMode where
   parseJSON _ = mempty
 instance ToJSON CitationMode where
   toJSON cmode =
-    object [ "t" .= String s
-           , "c" .= Aeson.emptyArray
-           ]
+    object [ "t" .= String s ]
     where s = case cmode of
             AuthorInText   -> "AuthorInText"
             SuppressAuthor -> "SuppressAuthor"
@@ -388,9 +386,7 @@ instance FromJSON QuoteType where
       _                    -> mempty
   parseJSON _ = mempty      
 instance ToJSON QuoteType where
-  toJSON qtype = object [ "t" .= String s
-                        , "c" .= Aeson.emptyArray
-                        ]
+  toJSON qtype = object [ "t" .= String s ]
     where s = case qtype of
             SingleQuote -> "SingleQuote"
             DoubleQuote -> "DoubleQuote"
@@ -405,9 +401,7 @@ instance FromJSON MathType where
       _                    -> mempty
   parseJSON _ = mempty      
 instance ToJSON MathType where
-  toJSON mtype = object [ "t" .= String s
-                        , "c" .= Aeson.emptyArray
-                        ]
+  toJSON mtype = object [ "t" .= String s ]
     where s = case mtype of
             DisplayMath -> "DisplayMath"
             InlineMath  -> "InlineMath"
@@ -426,9 +420,7 @@ instance FromJSON ListNumberStyle where
       _              -> mempty
   parseJSON _ = mempty      
 instance ToJSON ListNumberStyle where
-  toJSON lsty = object [ "t" .= String s
-                       , "c" .= Aeson.emptyArray
-                       ]
+  toJSON lsty = object [ "t" .= String s ]
     where s = case lsty of
             DefaultStyle -> "DefaultStyle"
             Example      -> "Example"
@@ -449,9 +441,7 @@ instance FromJSON ListNumberDelim where
       _                     -> mempty
   parseJSON _ = mempty      
 instance ToJSON ListNumberDelim where
-  toJSON delim = object [ "t" .= String s
-                        , "c" .= Aeson.emptyArray
-                        ]
+  toJSON delim = object [ "t" .= String s ]
     where s = case delim of
             DefaultDelim -> "DefaultDelim"
             Period       -> "Period"
@@ -469,9 +459,7 @@ instance FromJSON Alignment where
       _                     -> mempty
   parseJSON _ = mempty      
 instance ToJSON Alignment where
-  toJSON delim = object [ "t" .= String s
-                        , "c" .= Aeson.emptyArray
-                        ]
+  toJSON delim = object [ "t" .= String s ]
     where s = case delim of
             AlignLeft    -> "AlignLeft"
             AlignRight   -> "AlignRight"
@@ -561,17 +549,11 @@ instance ToJSON Inline where
                            ]
            ]
   toJSON Space =
-    object [ "t" .= String "Space"
-           , "c" .= Aeson.emptyArray
-           ]
+    object [ "t" .= String "Space" ]
   toJSON SoftBreak =
-    object [ "t" .= String "SoftBreak"
-           , "c" .= Aeson.emptyArray
-           ]
+    object [ "t" .= String "SoftBreak" ]
   toJSON LineBreak =
-    object [ "t" .= String "LineBreak"
-           , "c" .= Aeson.emptyArray
-           ]
+    object [ "t" .= String "LineBreak" ]
   toJSON (Math mtype s) =
     object [ "t" .= String "Math"
            , "c" .= Array [ toJSON mtype
@@ -682,9 +664,7 @@ instance ToJSON Block where
                           ]
            ]
   toJSON HorizontalRule =
-    object [ "t" .= String "HorizontalRule"
-           , "c" .= Aeson.emptyArray
-           ]
+    object [ "t" .= String "HorizontalRule" ]
   toJSON (Table caption aligns widths cells rows) =
     object [ "t" .= String "Table"
            , "c" .= Array [ toJSON caption
@@ -699,9 +679,7 @@ instance ToJSON Block where
            , "c" .= blks
            ]
   toJSON Null =
-    object [ "t" .= String "Null"
-           , "c" .= Aeson.emptyArray
-           ]
+    object [ "t" .= String "Null" ]
 
 instance FromJSON Pandoc where
   parseJSON (Object v) = do

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -287,9 +287,6 @@ data CitationMode = AuthorInText | SuppressAuthor | NormalCitation
 -- ToJSON/FromJSON instances. We do this by hand instead of deriving
 -- from generics, so we can have more control over the format.
 
-pandocApiVersion :: (Int, Int, Int)
-pandocApiVersion = (1,0,0)
-
 instance FromJSON MetaValue where
   parseJSON (Object v) = do
     t <- v .: "t" :: Aeson.Parser Value

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -314,14 +314,14 @@ parseJSON' = Aeson.genericParseJSON jsonOpts
 
 instance FromJSON MetaValue where
   parseJSON (Object v) = do
-    t <- v .: "t"
+    t <- v .: "t" :: Aeson.Parser Value
     case t of
-      String "MetaMap"     -> MetaMap     <$> (v .: "c")
-      String "MetaList"    -> MetaList    <$> (v .: "c")
-      String "MetaBool"    -> MetaBool    <$> (v .: "c")
-      String "MetaString"  -> MetaString  <$> (v .: "c")
-      String "MetaInlines" -> MetaInlines <$> (v .: "c")
-      String "MetaBlocks"  -> MetaBlocks  <$> (v .: "c")
+      "MetaMap"     -> MetaMap     <$> (v .: "c")
+      "MetaList"    -> MetaList    <$> (v .: "c")
+      "MetaBool"    -> MetaBool    <$> (v .: "c")
+      "MetaString"  -> MetaString  <$> (v .: "c")
+      "MetaInlines" -> MetaInlines <$> (v .: "c")
+      "MetaBlocks"  -> MetaBlocks  <$> (v .: "c")
       _ -> mempty
   parseJSON _ = mempty
 instance ToJSON MetaValue where
@@ -358,11 +358,11 @@ instance ToJSON Meta where
 
 instance FromJSON CitationMode where
   parseJSON (Object v) = do
-    t <- v .: "t"
+    t <- v .: "t" :: Aeson.Parser Value
     case t of
-      String "AuthorInText"   -> return AuthorInText
-      String "SuppressAuthor" -> return SuppressAuthor
-      String "NormalCitation" -> return NormalCitation
+      "AuthorInText"   -> return AuthorInText
+      "SuppressAuthor" -> return SuppressAuthor
+      "NormalCitation" -> return NormalCitation
       _ -> mempty
   parseJSON _ = mempty
 instance ToJSON CitationMode where
@@ -404,10 +404,10 @@ instance ToJSON Citation where
 
 instance FromJSON QuoteType where
   parseJSON (Object v) = do
-    t <- v .: "t"
+    t <- v .: "t" :: Aeson.Parser Value
     case t of
-      String "SingleQuote" -> return SingleQuote
-      String "DoubleQuote" -> return DoubleQuote
+      "SingleQuote" -> return SingleQuote
+      "DoubleQuote" -> return DoubleQuote
       _                    -> mempty
   parseJSON _ = mempty      
 instance ToJSON QuoteType where
@@ -421,10 +421,10 @@ instance ToJSON QuoteType where
 
 instance FromJSON MathType where
   parseJSON (Object v) = do
-    t <- v .: "t"
+    t <- v .: "t" :: Aeson.Parser Value
     case t of
-      String "DisplayMath" -> return DisplayMath
-      String "InlineMath"  -> return InlineMath
+      "DisplayMath" -> return DisplayMath
+      "InlineMath"  -> return InlineMath
       _                    -> mempty
   parseJSON _ = mempty      
 instance ToJSON MathType where
@@ -437,15 +437,15 @@ instance ToJSON MathType where
   
 instance FromJSON ListNumberStyle where
   parseJSON (Object v) = do
-    t <- v .: "t"
+    t <- v .: "t" :: Aeson.Parser Value
     case t of
-      String "DefaultStyle" -> return DefaultStyle
-      String "Example"      -> return Example
-      String "Decimal"      -> return Decimal
-      String "LowerRoman"   -> return LowerRoman
-      String "UpperRoman"   -> return UpperRoman
-      String "LowerAlpha"   -> return LowerAlpha
-      String "UpperAlpha"   -> return UpperAlpha
+      "DefaultStyle" -> return DefaultStyle
+      "Example"      -> return Example
+      "Decimal"      -> return Decimal
+      "LowerRoman"   -> return LowerRoman
+      "UpperRoman"   -> return UpperRoman
+      "LowerAlpha"   -> return LowerAlpha
+      "UpperAlpha"   -> return UpperAlpha
       _                     -> mempty
   parseJSON _ = mempty      
 instance ToJSON ListNumberStyle where
@@ -463,12 +463,12 @@ instance ToJSON ListNumberStyle where
 
 instance FromJSON ListNumberDelim where
   parseJSON (Object v) = do
-    t <- v .: "t"
+    t <- v .: "t" :: Aeson.Parser Value
     case t of
-      String "DefaultDelim" -> return DefaultDelim
-      String "Period"       -> return Period
-      String "OneParen"     -> return OneParen
-      String "TwoParens"    -> return TwoParens
+      "DefaultDelim" -> return DefaultDelim
+      "Period"       -> return Period
+      "OneParen"     -> return OneParen
+      "TwoParens"    -> return TwoParens
       _                     -> mempty
   parseJSON _ = mempty      
 instance ToJSON ListNumberDelim where
@@ -483,12 +483,12 @@ instance ToJSON ListNumberDelim where
 
 instance FromJSON Alignment where
   parseJSON (Object v) = do
-    t <- v .: "t"
+    t <- v .: "t" :: Aeson.Parser Value
     case t of
-      String "AlignLeft"    -> return AlignLeft
-      String "AlignRight"   -> return AlignRight
-      String "AlignCenter"  -> return AlignCenter
-      String "AlignDefault" -> return AlignDefault
+      "AlignLeft"    -> return AlignLeft
+      "AlignRight"   -> return AlignRight
+      "AlignCenter"  -> return AlignCenter
+      "AlignDefault" -> return AlignDefault
       _                     -> mempty
   parseJSON _ = mempty      
 instance ToJSON Alignment where
@@ -501,8 +501,40 @@ instance ToJSON Alignment where
             AlignCenter  -> "AlignCenter"
             AlignDefault -> "AlignDefault"
 
-instance FromJSON Inline
-  where parseJSON = parseJSON'
+
+instance FromJSON Inline where
+  parseJSON (Object v) = do
+    t <- v .: "t" :: Aeson.Parser Value
+    case t of
+      "Str"         -> Str <$> v .: "c"
+      "Emph"        -> Emph <$> v .: "c"
+      "Strong"      -> Strong <$> v .: "c"
+      "Strikeout"   -> Strikeout <$> v .: "c"
+      "Superscript" -> Superscript <$> v .: "c"
+      "Subscript"   -> Subscript <$> v .: "c"
+      "SmallCaps"   -> SmallCaps <$> v .: "c"
+      "Quoted"      -> do (qt, ils) <- v .: "c"
+                          return $ Quoted qt ils
+      "Cite"        -> do (cits, ils) <- v .: "c"
+                          return $ Cite cits ils
+      "Code"        -> do (attr, s) <- v .: "c"
+                          return $ Code attr s
+      "Space"       -> return Space
+      "SoftBreak"   -> return SoftBreak
+      "LineBreak"   -> return LineBreak
+      "Math"        -> do (mtype, s) <- v .: "c"
+                          return $ Math mtype s
+      "RawInline"   -> do (fmt, s) <- v .: "c"
+                          return $ RawInline fmt s
+      "Link"        -> do (attr, ils, tgt) <- v .: "c"
+                          return $ Link attr ils tgt
+      "Image"       -> do (attr, ils, tgt) <- v .: "c"
+                          return $ Image attr ils tgt
+      "Note"        -> Note <$> v .: "c"
+      "Span"        -> do (attr, ils) <- v .: "c"
+                          return $ Span attr ils
+      _ -> mempty
+  parseJSON _ = mempty
 
 instance ToJSON Inline where
   toJSON (Str s) =
@@ -589,7 +621,6 @@ instance ToJSON Inline where
                           , toJSON target
                           ]
            ]
-
   toJSON (Note blks) =
     object [ "t" .= String "Note"
            , "c" .= blks
@@ -601,8 +632,31 @@ instance ToJSON Inline where
                           ]
            ]
 
-instance FromJSON Block
-  where parseJSON = parseJSON'
+instance FromJSON Block where
+  parseJSON (Object v) = do
+    t <- v .: "t" :: Aeson.Parser Value
+    case t of
+      "Plain"          -> Plain <$> v .: "c"
+      "Para"           -> Para  <$> v .: "c"
+      "CodeBlock"      -> do (attr, s) <- v .: "c"
+                             return $ CodeBlock attr s
+      "RawBlock"       -> do (fmt, s) <- v .: "c"
+                             return $ CodeBlock fmt s
+      "BlockQuote"     -> BlockQuote <$> v .: "c"
+      "OrderedList"    -> do (attr, items) <- v .: "c"
+                             return $ OrderedList attr items
+      "BulletList"     -> BulletList <$> v .: "c"
+      "DefinitionList" -> DefinitionList <$> v .: "c"
+      "Header"         -> do (n, attr, ils) <- v .: "c"
+                             return $ Header n attr ils
+      "HorizontalRule" -> return $ HorizontalRule
+      "Table"          -> do (cpt, align, wdths, hdr, rows) <- v .: "c"
+                             return $ Table cpt align wdths hdr rows
+      "Div"            -> do (attr, blks) <- v .: "c"
+                             return $ Div attr blks
+      "Null"           -> return $ Null
+      _                -> mempty
+  parseJSON _ = mempty
 instance ToJSON Block where
   toJSON (Plain ils) =
     object [ "t" .= String "Plain"
@@ -672,8 +726,11 @@ instance ToJSON Block where
            , "c" .= Aeson.emptyArray
            ]
 
-instance FromJSON Pandoc
-  where parseJSON = parseJSON'
+instance FromJSON Pandoc where
+  parseJSON (Object v) = do
+    (meta, blks) <- v .: "c"
+    return $ Pandoc meta blks
+  parseJSON _ = mempty
 instance ToJSON Pandoc where
   toJSON (Pandoc meta blks) =
     Array [ toJSON meta

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -314,13 +314,36 @@ parseJSON' = Aeson.genericParseJSON jsonOpts
 
 instance FromJSON MetaValue
   where parseJSON = parseJSON'
-instance ToJSON MetaValue
-  where toJSON = toJSON'
+instance ToJSON MetaValue where
+  toJSON (MetaMap mp) =
+    object [ "t" .= String "MetaMap"
+           , "c" .= mp
+           ]
+  toJSON (MetaList lst) =
+    object [ "t" .= String "MetaList"
+           , "c" .= lst
+           ]
+  toJSON (MetaBool bool) =
+    object [ "t" .= String "MetaBool"
+           , "c" .= bool
+           ]
+  toJSON (MetaString s) =
+    object [ "t" .= String "MetaString"
+           , "c" .= s
+           ]
+  toJSON (MetaInlines ils) =
+    object [ "t" .= String "MetaInlines"
+           , "c" .= ils
+           ]
+  toJSON (MetaBlocks blks) =
+    object [ "t" .= String "MetaBlocks"
+           , "c" .= blks
+           ]
 
 instance FromJSON Meta
   where parseJSON = parseJSON'
-instance ToJSON Meta
-  where toJSON = toJSON'
+instance ToJSON Meta where
+  toJSON meta = object [ "unMeta" .= unMeta meta ]
 
 instance FromJSON CitationMode
   where parseJSON = parseJSON'
@@ -573,8 +596,11 @@ instance ToJSON Block where
 
 instance FromJSON Pandoc
   where parseJSON = parseJSON'
-instance ToJSON Pandoc
-  where toJSON = toJSON'
+instance ToJSON Pandoc where
+  toJSON (Pandoc meta blks) =
+    Array [ toJSON meta
+          , toJSON blks
+          ]
 
 -- Instances for deepseq
 #if MIN_VERSION_base(4,8,0)

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -44,14 +44,26 @@ Library
                      Text.Pandoc.Walk
                      Text.Pandoc.Builder
                      Text.Pandoc.JSON
+                     Text.Pandoc.Arbitrary
   Other-modules:     Paths_pandoc_types
   Build-depends:     base >= 4 && < 5,
                      containers >= 0.3,
                      syb >= 0.1 && < 0.7,
                      ghc-prim >= 0.2,
                      bytestring >= 0.9 && < 0.11,
-                     aeson >= 0.6.2 && < 1.1
+                     aeson >= 0.6.2 && < 1.1,
+                     QuickCheck >= 2
   if impl(ghc < 7.10)
     Build-depends:   deepseq-generics >= 0.1 && < 0.2
   else
     Build-depends:   deepseq >= 1.4.1 && < 1.5
+
+test-suite test-pandoc-types
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             test-pandoc-types.hs
+  build-depends:       base,
+                       pandoc-types,
+                       aeson >= 0.6.2 && < 1.1,
+                       QuickCheck >= 2
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -31,7 +31,7 @@ Bug-Reports:         https://github.com/jgm/pandoc-types/issues
 Copyright:           (c) 2006-2015 John MacFarlane
 Category:            Text
 Build-type:          Simple
-Cabal-version:       >=1.6
+Cabal-version:       >=1.8
 Tested-With:         GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.2
 Extra-Source-Files:  changelog
 Source-repository    head

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -9,6 +9,6 @@ prop_roundtrip doc = case decode $ encode doc :: (Maybe Pandoc) of
   _         -> False
 
 main :: IO ()
-main = quickCheckWith stdArgs { maxSuccess = 500 }  prop_roundtrip
+main = quickCheckWith stdArgs { maxSuccess = 100 }  prop_roundtrip
 
 

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -1,0 +1,14 @@
+import Text.Pandoc.Definition
+import Text.Pandoc.Arbitrary
+import Test.QuickCheck
+import Data.Aeson
+
+prop_roundtrip :: Pandoc -> Bool
+prop_roundtrip doc = case decode $ encode doc :: (Maybe Pandoc) of
+  Just doc' -> doc == doc'
+  _         -> False
+
+main :: IO ()
+main = quickCheckWith stdArgs { maxSuccess = 500 }  prop_roundtrip
+
+


### PR DESCRIPTION
1. This adds manual ToJSON and FromJSON instances, instead of the generic-derivied instances we had previously used. This should keep the format stable, regardless of  changes in aeson. Empirically, it also adds a small speedup in encoding and decoding.

2. This updates the pandoc json format. There are three main changes:

  1. The toplevel format is now
      
       ~~~{.json}
      {
         "pandoc-api-version": [1,7,1],
         "meta": [meta*],
         "blocks": [blocks*]
      }
      ~~~

      where `meta` and `blocks` are individual `Meta` and `Block` elements. Note that this means that the   toplevel is now an object, and that `meta` elements are no longer under an `unMeta` key.

  2. The "pandoc-api-version" tracks the pandoc-types version. If the major and minor versions (the 0th and 1st elements of the array) do not match, decoding in pandoc will fail. It is up to library writers in other languages to check and write these versions.

  3. Leaf elements (elements with no contents, like `Space`, `LineBreak`, and `HorinzontalRule`) will no longer have a `"c"` element. I.e. instead of `{"t": "Space", "c": []}`, we will output `{"t": "Space"}`. This probably won't affect many decoding functions, but it will be necessary for library writers to update their encoding functions for these elements.

3. Finally, this adds Arbitrary instances to pandoc-types, in `Text.Pandoc.Arbitrary`.
        