### PR TITLE
Default implementation for walk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dist
+/.stack-work

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -28,7 +28,7 @@ License-file:        LICENSE
 Author:              John MacFarlane
 Maintainer:          jgm@berkeley.edu
 Bug-Reports:         https://github.com/jgm/pandoc-types/issues
-Copyright:           (c) 2006-2015 John MacFarlane
+Copyright:           (c) 2006-2017 John MacFarlane
 Category:            Text
 Build-type:          Simple
 Cabal-version:       >=1.8
@@ -52,6 +52,7 @@ Library
                      ghc-prim >= 0.2,
                      bytestring >= 0.9 && < 0.11,
                      aeson >= 0.6.2 && < 1.3,
+                     transformers >= 0.2 && < 0.6,
                      QuickCheck >= 2
   if impl(ghc < 7.10)
     Build-depends:   deepseq-generics >= 0.1 && < 0.2


### PR DESCRIPTION
The implementations for `walk` and `walkM` are very similar, so a default method is provided which implements the former in terms of the latter. This change should not affect performance, as the `Identity` functor, which is used in the default definition, is a newtype that should be eliminated at compile time.

GHC 7.8 (i.e., base <= 4.7) does not provide the `Data.Functor.Identity` type, so we use the one included in the transformers library. The transformers library was already an indirect dependency due to Aeson, so while requiring it is ugly, it does not cause additional code to be included.

