### PR TITLE
Force optimizations when compiling Walk module

### DIFF
--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, ScopedTypeVariables, CPP #-}
 #if MIN_VERSION_base(4,9,0)
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints -O2 #-}
 #endif
 #if MIN_VERSION_base(4,8,0)
 #define OVERLAPS {-# OVERLAPPING #-}
@@ -9,7 +9,7 @@
 #define OVERLAPS
 #endif
 {-
-Copyright (c) 2013-2016, John MacFarlane
+Copyright (c) 2013-2017, John MacFarlane
 
 All rights reserved.
 


### PR DESCRIPTION
The functions defined in the Walk module are relatively simple while
being called recursively on possibly long documents. It hence seems
sensible to force optimizations for this module, as the benefits likely
outweigh the additional compile time.

This also reduces the performance cost of having a default
implementation for `walk` based on `walkM`.
