### PR TITLE
Walkable element lists

### DIFF
--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -89,7 +89,7 @@ linked to in a document:
 
 module Text.Pandoc.Walk (Walkable(..))
 where
-import Control.Applicative ((<$>))
+import Control.Applicative (Applicative, (<$>))
 import Data.Functor.Identity (Identity (runIdentity))
 import Text.Pandoc.Definition
 import qualified Data.Traversable as T
@@ -108,7 +108,7 @@ class Walkable a b where
   walk  :: (a -> a) -> b -> b
   walk f = runIdentity . walkM (return . f)
   -- | A monadic version of 'walk'.
-  walkM :: (Monad m, Functor m) => (a -> m a) -> b -> m b
+  walkM :: (Monad m, Applicative m, Functor m) => (a -> m a) -> b -> m b
   -- | @query f x@ walks the structure @x@ (bottom up) and applies @f@
   -- to every @a@, appending the results.
   query :: Monoid c => (a -> c) -> b -> c

--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -234,7 +234,7 @@ instance Walkable Inline Block where
                                      hs' <- walkM f hs
                                      rs' <- walkM f rs
                                      return $ Table capt' as ws hs' rs'
-  walkM f (Div attr bs)            = Div attr <$> (walkM f bs)
+  walkM f (Div attr bs)            = Div attr <$> walkM f bs
   walkM _ Null                     = return Null
 
   query f (Para xs)                = query f xs
@@ -317,6 +317,45 @@ instance Walkable Block Block where
   query f (Div attr bs)            = f (Div attr bs) <> query f bs
   query f Null                     = f Null
 
+instance OVERLAPS
+         Walkable [Block] [Block] where
+  walkM f = T.traverse walkBlockM >=> f
+   where
+    walkBlockM (Para xs)                = Para <$> walkM f xs
+    walkBlockM (Plain xs)               = Plain <$> walkM f xs
+    walkBlockM (LineBlock xs)           = LineBlock <$> walkM f xs
+    walkBlockM (BlockQuote xs)          = BlockQuote <$> walkM f xs
+    walkBlockM (OrderedList a cs)       = OrderedList a <$> walkM f cs
+    walkBlockM (BulletList cs)          = BulletList <$> walkM f cs
+    walkBlockM (DefinitionList xs)      = DefinitionList <$> walkM f xs
+    walkBlockM (Header lev attr xs)     = Header lev attr <$> walkM f xs
+    walkBlockM (Div attr bs')           = Div attr <$> walkM f bs'
+    walkBlockM x@CodeBlock {}           = return x
+    walkBlockM x@RawBlock {}            = return x
+    walkBlockM HorizontalRule           = return HorizontalRule
+    walkBlockM Null                     = return Null
+    walkBlockM (Table capt as ws hs rs) = do capt' <- walkM f capt
+                                             hs' <- walkM f hs
+                                             rs' <- walkM f rs
+                                             return $ Table capt' as ws hs' rs'
+
+  query f blks = f blks <> mconcat (map queryBlocks blks)
+   where
+     queryBlocks (Para xs)              = query f xs
+     queryBlocks (Plain xs)             = query f xs
+     queryBlocks (LineBlock xs)         = query f xs
+     queryBlocks CodeBlock {}           = mempty
+     queryBlocks RawBlock {}            = mempty
+     queryBlocks (BlockQuote bs)        = query f bs
+     queryBlocks (OrderedList _ cs)     = query f cs
+     queryBlocks (BulletList cs)        = query f cs
+     queryBlocks (DefinitionList xs)    = query f xs
+     queryBlocks (Header _ _ xs)        = query f xs
+     queryBlocks HorizontalRule         = mempty
+     queryBlocks (Table capt _ _ hs rs) = query f capt <> query f hs <> query f rs
+     queryBlocks (Div _ bs)             = query f bs
+     queryBlocks Null                   = mempty
+
 instance Walkable Block Inline where
   walkM _ (Str xs)        = return $ Str xs
   walkM f (Emph xs)       = Emph <$> walkM f xs
@@ -360,7 +399,57 @@ instance Walkable Block Inline where
   query f (Note bs)       = query f bs
   query f (Span _ xs)     = query f xs
 
+instance Walkable [Block] Inline where
+  walkM _ (Str xs)        = return $ Str xs
+  walkM f (Emph xs)       = Emph <$> walkM f xs
+  walkM f (Strong xs)     = Strong <$> walkM f xs
+  walkM f (Strikeout xs)  = Strikeout <$> walkM f xs
+  walkM f (Subscript xs)  = Subscript <$> walkM f xs
+  walkM f (Superscript xs)= Superscript <$> walkM f xs
+  walkM f (SmallCaps xs)  = SmallCaps <$> walkM f xs
+  walkM f (Quoted qt xs)  = Quoted qt <$> walkM f xs
+  walkM f (Cite cs xs)    = do cs' <- walkM f cs
+                               xs' <- walkM f xs
+                               return $ Cite cs' xs'
+  walkM _ (Code attr s)   = return $ Code attr s
+  walkM _ Space           = return Space
+  walkM _ SoftBreak       = return SoftBreak
+  walkM _ LineBreak       = return LineBreak
+  walkM _ (Math mt s)     = return $ Math mt s
+  walkM _ (RawInline t s) = return $ RawInline t s
+  walkM f (Link atr xs t) = (\lab -> Link atr lab t) <$> walkM f xs
+  walkM f (Image atr xs t)= (\lab -> Image atr lab t) <$> walkM f xs
+  walkM f (Note bs)       = Note <$> walkM f bs
+  walkM f (Span attr xs)  = Span attr <$> walkM f xs
+
+  query _ (Str _)         = mempty
+  query f (Emph xs)       = query f xs
+  query f (Strong xs)     = query f xs
+  query f (Strikeout xs)  = query f xs
+  query f (Subscript xs)  = query f xs
+  query f (Superscript xs)= query f xs
+  query f (SmallCaps xs)  = query f xs
+  query f (Quoted _ xs)   = query f xs
+  query f (Cite cs xs)    = query f cs <> query f xs
+  query _ (Code _ _)      = mempty
+  query _ Space           = mempty
+  query _ SoftBreak       = mempty
+  query _ LineBreak       = mempty
+  query _ (Math _ _)      = mempty
+  query _ (RawInline _ _) = mempty
+  query f (Link _ xs _)   = query f xs
+  query f (Image _ xs _)  = query f xs
+  query f (Note bs)       = query f bs
+  query f (Span _ xs)     = query f xs
+
 instance Walkable Block Pandoc where
+  walk f (Pandoc m bs)  = Pandoc (walk f m) (walk f bs)
+  walkM f (Pandoc m bs) = do m' <- walkM f m
+                             bs' <- walkM f bs
+                             return $ Pandoc m' bs'
+  query f (Pandoc m bs) = query f m <> query f bs
+
+instance Walkable [Block] Pandoc where
   walk f (Pandoc m bs)  = Pandoc (walk f m) (walk f bs)
   walkM f (Pandoc m bs) = do m' <- walkM f m
                              bs' <- walkM f bs
@@ -402,6 +491,11 @@ instance Walkable [Inline] Meta where
   query f (Meta metamap) = query f metamap
 
 instance Walkable Block Meta where
+  walk f (Meta metamap)  = Meta $ walk f metamap
+  walkM f (Meta metamap) = Meta <$> walkM f metamap
+  query f (Meta metamap) = query f metamap
+
+instance Walkable [Block] Meta where
   walk f (Meta metamap)  = Meta $ walk f metamap
   walkM f (Meta metamap) = Meta <$> walkM f metamap
   query f (Meta metamap) = query f metamap
@@ -451,6 +545,21 @@ instance Walkable Block MetaValue where
   query f (MetaBlocks bs)  = query f bs
   query f (MetaMap m)      = query f m
 
+instance Walkable [Block] MetaValue where
+  walkM f (MetaList xs)    = MetaList <$> walkM f xs
+  walkM _ (MetaBool b)     = return $ MetaBool b
+  walkM _ (MetaString s)   = return $ MetaString s
+  walkM f (MetaInlines xs) = MetaInlines <$> walkM f xs
+  walkM f (MetaBlocks bs)  = MetaBlocks <$> walkM f bs
+  walkM f (MetaMap m)      = MetaMap <$> walkM f m
+
+  query f (MetaList xs)    = query f xs
+  query _ (MetaBool _)     = mempty
+  query _ (MetaString _)   = mempty
+  query f (MetaInlines xs) = query f xs
+  query f (MetaBlocks bs)  = query f bs
+  query f (MetaMap m)      = query f m
+
 instance Walkable Inline Citation where
   walk f (Citation id' pref suff mode notenum hash) =
     Citation id' (walk f pref) (walk f suff) mode notenum hash
@@ -473,6 +582,16 @@ instance Walkable [Inline] Citation where
 
 
 instance Walkable Block Citation where
+  walk f (Citation id' pref suff mode notenum hash) =
+    Citation id' (walk f pref) (walk f suff) mode notenum hash
+  walkM f (Citation id' pref suff mode notenum hash) =
+    do pref' <- walkM f pref
+       suff' <- walkM f suff
+       return $ Citation id' pref' suff' mode notenum hash
+  query f (Citation _ pref suff _ _ _) =
+    query f pref <> query f suff
+
+instance Walkable [Block] Citation where
   walk f (Citation id' pref suff mode notenum hash) =
     Citation id' (walk f pref) (walk f suff) mode notenum hash
   walkM f (Citation id' pref suff mode notenum hash) =

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -59,6 +59,12 @@ blockTrans (Plain xs) = Para xs
 blockTrans (BlockQuote xs) = Div ("",["special"],[]) xs
 blockTrans x = x
 
+blocksTrans :: [Block] -> [Block]
+blocksTrans [CodeBlock {}] = []
+blocksTrans [BlockQuote xs] = xs
+blocksTrans [Div _ xs] = xs
+blocksTrans xs = xs
+
 inlineQuery :: Inline -> String
 inlineQuery (Str xs) = xs
 inlineQuery _ = ""
@@ -69,6 +75,9 @@ inlinesQuery = Monoid.Sum . length
 blockQuery :: Block -> [Int]
 blockQuery (Header lev _ _) = [lev]
 blockQuery _ = []
+
+blocksQuery :: [Block] -> Monoid.Sum Int
+blocksQuery = Monoid.Sum . length
 
 
 prop_roundtrip :: Pandoc -> Bool
@@ -363,6 +372,8 @@ tests =
     , testProperty "p_query blockQuery" (p_query blockQuery)
     , testProperty "p_walkList inlinesTrans"  (p_walkList inlinesTrans)
     , testProperty "p_queryList inlinesQuery" (p_queryList inlinesQuery)
+    , testProperty "p_walkList blocksTrans"  (p_walkList blocksTrans)
+    , testProperty "p_queryList blocksQuery" (p_queryList blocksQuery)
     ]
   , testGroup "JSON"
     [ testGroup "encoding/decoding properties"

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -4,6 +4,7 @@ import Text.Pandoc.Arbitrary ()
 import Text.Pandoc.Definition
 import Text.Pandoc.Walk
 import Data.Generics
+import Data.List (tails)
 import Test.HUnit (Assertion, assertEqual, assertFailure)
 import Data.Char (toUpper)
 import Data.Aeson (FromJSON, ToJSON, encode, decode)
@@ -17,20 +18,41 @@ import Data.ByteString.Lazy (ByteString)
 #else
 import Data.Monoid
 #endif
+import qualified Data.Monoid as Monoid
 
 
 p_walk :: (Typeable a, Walkable a Pandoc)
        => (a -> a) -> Pandoc -> Bool
 p_walk f d = everywhere (mkT f) d == walk f d
 
+p_walkList :: (Typeable a, Walkable [a] Pandoc)
+       => ([a] -> [a]) -> Pandoc -> Bool
+p_walkList f d = everywhere (mkT f) d == walk (foldr g []) d
+  where g x ys = f (x:ys)
+
 p_query :: (Eq a, Typeable a1, Monoid a, Walkable a1 Pandoc)
         => (a1 -> a) -> Pandoc -> Bool
 p_query f d = everything mappend (mempty `mkQ` f) d == query f d
+
+p_queryList :: (Eq a, Typeable a1, Monoid a, Walkable [a1] Pandoc)
+            => ([a1] -> a) -> Pandoc -> Bool
+p_queryList f d = everything mappend (mempty `mkQ` f) d ==
+                  query (mconcat . map f . tails) d
 
 inlineTrans :: Inline -> Inline
 inlineTrans (Str xs) = Str $ map toUpper xs
 inlineTrans (Emph xs) = Strong xs
 inlineTrans x = x
+
+inlinesTrans :: [Inline] -> [Inline]
+inlinesTrans ys | all whitespaceInline ys = []
+  where
+    whitespaceInline Space = True
+    whitespaceInline LineBreak = True
+    whitespaceInline SoftBreak = True
+    whitespaceInline (Str "") = True
+    whitespaceInline _ = False
+inlinesTrans ys = ys
 
 blockTrans :: Block -> Block
 blockTrans (Plain xs) = Para xs
@@ -40,6 +62,9 @@ blockTrans x = x
 inlineQuery :: Inline -> String
 inlineQuery (Str xs) = xs
 inlineQuery _ = ""
+
+inlinesQuery :: [Inline] -> Monoid.Sum Int
+inlinesQuery = Monoid.Sum . length
 
 blockQuery :: Block -> [Int]
 blockQuery (Header lev _ _) = [lev]
@@ -336,6 +361,8 @@ tests =
     , testProperty "p_walk blockTrans" (p_walk blockTrans)
     , testProperty "p_query inlineQuery" (p_query inlineQuery)
     , testProperty "p_query blockQuery" (p_query blockQuery)
+    , testProperty "p_walkList inlinesTrans"  (p_walkList inlinesTrans)
+    , testProperty "p_queryList inlinesQuery" (p_queryList inlinesQuery)
     ]
   , testGroup "JSON"
     [ testGroup "encoding/decoding properties"

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE OverloadedStrings, QuasiQuotes, FlexibleContexts, CPP #-}
 
+import Text.Pandoc.Arbitrary ()
 import Text.Pandoc.Definition
 import Text.Pandoc.Walk
-import Text.Pandoc.Arbitrary()
 import Data.Generics
 import Test.HUnit (Assertion, assertEqual, assertFailure)
-import Text.Pandoc.Arbitrary ()
 import Data.Char (toUpper)
 import Data.Aeson (FromJSON, ToJSON, encode, decode)
 import Test.Framework


### PR DESCRIPTION
Add Walkable instances for lists of Inlines and lists of Blocks.  This is a prerequisite for jgm/pandoc#3926.
