### PR TITLE
WIP: Hal 2017

### DIFF
--- a/Text/Pandoc/Arbitrary.hs
+++ b/Text/Pandoc/Arbitrary.hs
@@ -20,7 +20,7 @@ arbAttr = do
   id' <- elements ["","loc"]
   classes <- elements [[],["haskell"],["c","numberLines"]]
   keyvals <- elements [[],[("start","22")],[("a","11"),("b_2","a b c")]]
-  return $ Attr (id',classes,keyvals)
+  return (id',classes,keyvals)
 
 instance IsString string => Arbitrary (Inlines' string) where
   arbitrary = liftM (fromList :: [Inline' string] -> Inlines' string) arbitrary

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -245,17 +245,16 @@ instance ConvertibleStrings String string => IsString (Inlines' string) where
    fromString = text
 
 -- | Trim leading and trailing spaces and softbreaks from an Inlines.
-trimInlines :: (ConvertibleStrings string String, ConvertibleStrings String string)  -- TODO: go via LT, not String
-            => Inlines' string -> Inlines' string
+trimInlines :: Inlines' string -> Inlines' string
 #if MIN_VERSION_containers(0,4,0)
-trimInlines (Many ils) = Many $ undefined {- fmap cs -} $ Seq.dropWhileL isSp $
-                            Seq.dropWhileR isSp $ undefined {- fmap cs -} $ ils
+trimInlines (Many ils) = Many $ Seq.dropWhileL isSp $
+                            Seq.dropWhileR isSp $ ils
 #else
 -- for GHC 6.12, we need to workaround a bug in dropWhileR
 -- see http://hackage.haskell.org/trac/ghc/ticket/4157
-trimInlines (Many ils) = Many $ undefined {- fmap cs -} $ Seq.dropWhileL isSp
+trimInlines (Many ils) = Many $ Seq.dropWhileL isSp
                             Seq.reverse $ Seq.dropWhileL isSp $
-                            Seq.reverse $ undefined {- fmap cs ils -}
+                            Seq.reverse $ ils
 #endif
   where isSp Space = True
         isSp SoftBreak = True

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -69,7 +69,7 @@ module Text.Pandoc.Definition ( Pandoc
                               , ListNumberDelim(..)
                               , Format(..)
                               , Attr
-                              , Attr'(..)
+                              , Attr'
                               , nullAttr
                               , TableCell
                               , TableCell'
@@ -207,17 +207,11 @@ data ListNumberDelim = DefaultDelim
 type Attr = Attr' String
 
 -- | Attributes: identifier, classes, key-value pairs
-newtype Attr' string = Attr (string, [string], [(string, string)])
-  deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
-
-instance FromJSON string => FromJSON (Attr' string) where
-  parseJSON v = Attr <$> parseJSON v
-
-instance ToJSON string => ToJSON (Attr' string) where
-  toJSON (Attr d) = toJSON d
+-- TODO: make this a newtype
+type Attr' string = (string, [string], [(string, string)])
 
 nullAttr :: IsString string => Attr' string
-nullAttr = Attr ("",[],[])
+nullAttr = ("",[],[])
 
 type TableCell = TableCell' String
 
@@ -645,7 +639,6 @@ instance NFData string => NFData (Meta' string)
 instance NFData string => NFData (Citation' string)
 instance NFData Alignment
 instance NFData string => NFData (Inline' string)
-instance NFData string => NFData (Attr' string)
 instance NFData MathType
 instance NFData Format
 instance NFData CitationMode

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -226,13 +226,15 @@ type TableCell' string = [Block' string]
 
 -- | Formats for raw blocks
 --
--- TODO: changing this type to use ST or LT internally is a breaking change, and using a polymorphic
--- type like with the others is a bit tricky, since we need to suddenly write lots of instances
--- manually that could formerly be derived.  try it and follow the type errors!
+-- TODO: changing this type to use ST or LT internally is a breaking change, and
+-- using a polymorphic type like with the others is a bit tricky, since we need
+-- to suddenly write lots of instances manually that could formerly be derived.
+-- try it and follow the type errors!
 --
--- TODO: introduce @mkFormat = Format . map toLower . cs :: ConvertibleStrings string String =>
--- string -> Format@ and make 'Format' abstract (do not export constructor), then we don't have to
--- worry about Eq, Ord distinguishing upper and lower case.
+-- TODO: introduce @mkFormat = Format . map toLower . cs :: ConvertibleStrings
+-- string String => string -> Format@ and make 'Format' abstract (do not export
+-- constructor), then we don't have to worry about Eq, Ord distinguishing upper
+-- and lower case.
 newtype Format = Format String
                deriving (Read, Show, Typeable, Data, Generic, ToJSON, FromJSON)
 

--- a/benchmark/bench.hs
+++ b/benchmark/bench.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import Criterion.Main (bench, defaultMain, nf)
-import Text.Pandoc.Definition (Pandoc, Inline (Str))
+import Data.String.Conversions
 import Text.Pandoc.Walk (walk)
-import Text.Pandoc.Builder
+import Text.Pandoc.Builder hiding (Pandoc, Meta, MetaValue, Inline, Block, Citation)
+
+type TestStringType = String
+
+-- redefining these so we can easily replace 'String' with another type just for testing.
+type Pandoc = Pandoc' TestStringType
+type Inline = Inline' TestStringType
+
 
 main :: IO ()
 main = do
@@ -14,16 +21,16 @@ main = do
     ]
 
 prependZeroWidthSpace :: Inline -> Inline
-prependZeroWidthSpace (Str s) = Str ('\8203' : s)
+prependZeroWidthSpace (Str s) = Str ("\8203" <> s)
 prependZeroWidthSpace x = x
 
 prependZeroWidthSpace' :: Inline -> [Inline]
-prependZeroWidthSpace' (Str s) = [Str ('\8203' : s)]
+prependZeroWidthSpace' (Str s) = [Str ("\8203" <> s)]
 prependZeroWidthSpace' x = [x]
 
 prependZeroWidthSpace'' :: [Inline] -> [Inline]
 prependZeroWidthSpace'' (Str s : xs) =
-  (Str ('\8203' : s) : prependZeroWidthSpace'' xs)
+  (Str ("\8203" <> s) : prependZeroWidthSpace'' xs)
 prependZeroWidthSpace'' (x : xs) =
   x : prependZeroWidthSpace'' xs
 prependZeroWidthSpace'' [] = []

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -53,7 +53,9 @@ Library
                      bytestring >= 0.9 && < 0.11,
                      aeson >= 0.6.2 && < 1.3,
                      transformers >= 0.2 && < 0.6,
-                     QuickCheck >= 2
+                     QuickCheck >= 2,
+                     text >= 1.2.2.1 && < 1.3,
+                     string-conversions >= 0.4.0.1 && < 0.5
   if impl(ghc < 7.10)
     Build-depends:   deepseq-generics >= 0.1 && < 0.2
   else
@@ -75,7 +77,8 @@ test-suite test-pandoc-types
                        test-framework-quickcheck2 >= 0.2.9 && < 0.4,
                        QuickCheck >= 2.4 && < 2.11,
                        HUnit >= 1.2 && < 1.7,
-                       string-qq == 0.0.2
+                       string-qq == 0.0.2,
+                       string-conversions >= 0.4.0.1 && < 0.5
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -O2
 
 benchmark benchmark-pandoc-types
@@ -84,5 +87,6 @@ benchmark benchmark-pandoc-types
   hs-source-dirs:  benchmark
   build-depends:   pandoc-types,
                    base >= 4.2 && < 5,
-                   criterion >= 1.0 && < 1.3
+                   criterion >= 1.0 && < 1.3,
+                   string-conversions >= 0.4.0.1 && < 0.5
   ghc-options:   -rtsopts -Wall -fno-warn-unused-do-bind -O2

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -68,7 +68,7 @@ inlinesTrans ys = ys
 
 blockTrans :: Block -> Block
 blockTrans (Plain xs) = Para xs
-blockTrans (BlockQuote xs) = Div (Attr ("",["special"],[])) xs
+blockTrans (BlockQuote xs) = Div ("",["special"],[]) xs
 blockTrans x = x
 
 blocksTrans :: [Block] -> [Block]
@@ -230,7 +230,7 @@ t_cite = ( Cite [Citation { citationId = "jameson:unconscious"
              )
 
 t_code :: (Inline, ByteString)
-t_code = ( Code (Attr ("", [], [("language", "haskell")])) "foo bar"
+t_code = ( Code ("", [], [("language", "haskell")]) "foo bar"
          , [s|{"t":"Code","c":[["",[],[["language","haskell"]]],"foo bar"]}|]
          )
 
@@ -249,14 +249,14 @@ t_rawinline = ( RawInline (Format "tex") "\\foo{bar}"
               )
 
 t_link :: (Inline, ByteString)
-t_link = ( Link (Attr ("id",["kls"],[("k1", "v1"), ("k2", "v2")]))
+t_link = ( Link ("id",["kls"],[("k1", "v1"), ("k2", "v2")])
            [ Str "a", Space, Str "famous", Space, Str "site"]
            ("https://www.google.com","google")
          , [s|{"t":"Link","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Str","c":"a"},{"t":"Space"},{"t":"Str","c":"famous"},{"t":"Space"},{"t":"Str","c":"site"}],["https://www.google.com","google"]]}|]
          )
 
 t_image :: (Inline, ByteString)
-t_image = ( Image (Attr ("id",["kls"],[("k1", "v1"), ("k2", "v2")]))
+t_image = ( Image ("id",["kls"],[("k1", "v1"), ("k2", "v2")])
            [ Str "a", Space, Str "famous", Space, Str "image"]
            ("my_img.png","image")
          , [s|{"t":"Image","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Str","c":"a"},{"t":"Space"},{"t":"Str","c":"famous"},{"t":"Space"},{"t":"Str","c":"image"}],["my_img.png","image"]]}|]
@@ -268,7 +268,7 @@ t_note = ( Note [Para [Str "Hello"]]
          )
 
 t_span :: (Inline, ByteString)
-t_span = ( Span (Attr ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])) [Str "Hello"]
+t_span = ( Span ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) [Str "Hello"]
          , [s|{"t":"Span","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Str","c":"Hello"}]]}|]
          )
 
@@ -288,7 +288,7 @@ t_lineblock = ( LineBlock [[Str "Hello"], [Str "Moin"]]
               )
 
 t_codeblock :: (Block, ByteString)
-t_codeblock = ( CodeBlock (Attr ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])) "Foo Bar"
+t_codeblock = ( CodeBlock ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) "Foo Bar"
               , [s|{"t":"CodeBlock","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],"Foo Bar"]}|]
               )
 
@@ -326,7 +326,7 @@ t_definitionlist = (DefinitionList
                     )
 
 t_header :: (Block, ByteString)
-t_header = ( Header 2 (Attr ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])) [Str "Head"]
+t_header = ( Header 2 ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) [Str "Head"]
            , [s|{"t":"Header","c":[2,["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Str","c":"Head"}]]}|]
            )
 
@@ -367,7 +367,7 @@ t_table = (  Table
               )
 
 t_div :: (Block, ByteString)
-t_div = ( Div (Attr ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])) [Para [Str "Hello"]]
+t_div = ( Div ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) [Para [Str "Hello"]]
          , [s|{"t":"Div","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Para","c":[{"t":"Str","c":"Hello"}]}]]}|]
          )
 


### PR DESCRIPTION
See jgm/pandoc#1852.  This is work in the context of http://nfa.imn.htwk-leipzig.de/HAL2017/.

Make most types polymoprhic in the string type, and use the convertible-strings package to use lazy text internally.  This is a non-breaking change; the new type is `Inline' string`, and there is an alias `Inline = Inline' String`.

The polymorphism can be rolled back later if everybody uses the new pandoc string type, but it's possible that there is no performance penalty as ghc can compile all the `id` conversions away.