### PR TITLE
Add extra imports to fix build on older GHCs

### DIFF
--- a/Text/Pandoc/Arbitrary.hs
+++ b/Text/Pandoc/Arbitrary.hs
@@ -4,6 +4,7 @@
 module Text.Pandoc.Arbitrary ()
 where
 import Test.QuickCheck
+import Control.Applicative (Applicative ((<*>), pure), (<$>))
 import Control.Monad (forM)
 import Text.Pandoc.Definition
 import Text.Pandoc.Builder

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -84,7 +84,7 @@ import Data.Char (toLower)
 #if MIN_VERSION_base(4,8,0)
 import Control.DeepSeq
 #else
-import Data.Monoid
+import Data.Monoid (Monoid (mappend, mempty))
 import Control.Applicative ((<$>), (<*>))
 import Control.DeepSeq.Generics
 #endif

--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -93,14 +93,14 @@ linked to in a document:
 
 module Text.Pandoc.Walk (Walkable(..))
 where
-import Control.Applicative ()
+import Control.Applicative (Applicative ((<*>), pure), (<$>))
 import Control.Monad ((>=>))
 import Data.Functor.Identity (Identity (runIdentity))
 import Text.Pandoc.Definition
 import qualified Data.Traversable as T
-import Data.Traversable ()
+import Data.Traversable (Traversable)
 import qualified Data.Foldable as F
-import Data.Foldable ()
+import Data.Foldable (Foldable)
 #if MIN_VERSION_base(4,8,0)
 import Data.Monoid ((<>))
 #else


### PR DESCRIPTION
As a hackage trustee, I've made revisions to versions 1.17.4.2 and 1.17.4.1 to increase their base lower bounds to `>= 4.8` and `>=4.9` respectively.

This patch will make pandoc-types compile as far back as GHC 7.4