### PR TITLE
Change homepage to pandoc.org

### DIFF
--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -22,7 +22,7 @@ Description:         @Text.Pandoc.Definition@ defines the 'Pandoc' data
                      @Text.Pandoc.JSON@ provides functions for serializing
                      and deserializing a @Pandoc@ structure to and from JSON.
 
-Homepage:            http://johnmacfarlane.net/pandoc
+Homepage:            https://pandoc.org/
 License:             BSD3
 License-file:        LICENSE
 Author:              John MacFarlane


### PR DESCRIPTION
The URL currently listed as the homepage just redirects to `pandoc.org`.