### PR TITLE
Use Text instead of String internally

### DIFF
--- a/Text/Pandoc/Arbitrary.hs
+++ b/Text/Pandoc/Arbitrary.hs
@@ -1,17 +1,23 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE FlexibleInstances, ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances, ScopedTypeVariables, OverloadedStrings #-}
 -- provides Arbitrary instance for Pandoc types
 module Text.Pandoc.Arbitrary ()
 where
 import Test.QuickCheck
 import Control.Applicative (Applicative ((<*>), pure), (<$>))
 import Control.Monad (forM)
+import Data.Text (Text)
+import qualified Data.Text as T
 import Text.Pandoc.Definition
 import Text.Pandoc.Builder
 
-realString :: Gen String
-realString = resize 8 $ listOf $ frequency [ (9, elements [' '..'\127'])
-                                           , (1, elements ['\128'..'\9999']) ]
+realString :: Gen Text
+realString = fmap T.pack $ resize 8 $ listOf $ frequency [ (9, elements [' '..'\127'])
+                                                         , (1, elements ['\128'..'\9999']) ]
+
+instance Arbitrary Text where
+  arbitrary = T.pack <$> arbitrary
+  shrink xs = T.pack <$> shrink (T.unpack xs)
 
 arbAttr :: Gen Attr
 arbAttr = do
@@ -238,7 +244,7 @@ instance Arbitrary CitationMode where
 
 instance Arbitrary Citation where
         arbitrary
-          = Citation <$> listOf (elements $ ['a'..'z'] ++ ['0'..'9'] ++ ['_'])
+          = Citation <$> fmap T.pack (listOf $ elements $ ['a'..'z'] ++ ['0'..'9'] ++ ['_'])
                      <*> arbInlines 1
                      <*> arbInlines 1
                      <*> arbitrary

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -297,7 +297,7 @@ instance HasMeta Pandoc where
     Pandoc (Meta $ M.delete key ms) bs
 
 setTitle :: Inlines -> Pandoc -> Pandoc
-setTitle = setMeta  "title"
+setTitle = setMeta "title"
 
 setAuthors :: [Inlines] -> Pandoc -> Pandoc
 setAuthors = setMeta "author"

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -201,13 +201,13 @@ newtype Format = Format Text
                deriving (Read, Show, Typeable, Data, Generic, ToJSON, FromJSON)
 
 instance IsString Format where
-  fromString f = Format $ T.toLower $ T.pack f
+  fromString f = Format $ T.toCaseFold $ T.pack f
 
 instance Eq Format where
-  Format x == Format y = T.toLower x == T.toLower y
+  Format x == Format y = T.toCaseFold x == T.toCaseFold y
 
 instance Ord Format where
-  compare (Format x) (Format y) = compare (T.toLower x) (T.toLower y)
+  compare (Format x) (Format y) = compare (T.toCaseFold x) (T.toCaseFold y)
 
 -- | Block element.
 data Block

--- a/Text/Pandoc/JSON.hs
+++ b/Text/Pandoc/JSON.hs
@@ -76,6 +76,7 @@ import Text.Pandoc.Definition
 import Text.Pandoc.Walk
 import Data.Maybe (listToMaybe)
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
 import Data.Aeson
 import System.Environment (getArgs)
 
@@ -126,4 +127,4 @@ instance (ToJSONFilter a) => ToJSONFilter ([String] -> a) where
   toJSONFilter f = getArgs >>= toJSONFilter . f
 
 instance (ToJSONFilter a) => ToJSONFilter (Maybe Format -> a) where
-  toJSONFilter f = getArgs >>= toJSONFilter . f . fmap Format . listToMaybe
+  toJSONFilter f = getArgs >>= toJSONFilter . f . fmap (Format . T.pack) . listToMaybe

--- a/Text/Pandoc/Legacy/Builder.hs
+++ b/Text/Pandoc/Legacy/Builder.hs
@@ -1,0 +1,162 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module Text.Pandoc.Legacy.Builder
+  ( module Text.Pandoc.Legacy.Definition
+  , B.Many(..)
+  , B.Inlines
+  , B.Blocks
+  , (<>)
+  , B.singleton
+  , B.toList
+  , B.fromList
+  , B.isNull
+  , B.doc
+  , ToMetaValue(..)
+  , HasMeta(..)
+  , B.setTitle
+  , B.setAuthors
+  , B.setDate
+  , text
+  , str
+  , B.emph
+  , B.strong
+  , B.strikeout
+  , B.superscript
+  , B.subscript
+  , B.smallcaps
+  , B.singleQuoted
+  , B.doubleQuoted
+  , B.cite
+  , codeWith
+  , code
+  , B.space
+  , B.softbreak
+  , B.linebreak
+  , math
+  , displayMath
+  , rawInline
+  , link
+  , linkWith
+  , image
+  , imageWith
+  , B.note
+  , spanWith
+  , B.trimInlines
+  , B.para
+  , B.plain
+  , B.lineBlock
+  , codeBlockWith
+  , codeBlock
+  , rawBlock
+  , B.blockQuote
+  , B.bulletList
+  , B.orderedListWith
+  , B.orderedList
+  , B.definitionList
+  , B.header
+  , headerWith
+  , B.horizontalRule
+  , B.table
+  , B.simpleTable
+  , divWith
+  ) where
+
+import qualified Data.Map as M
+import qualified Data.Text as T
+import qualified Text.Pandoc.Builder as B
+import Text.Pandoc.Legacy.Definition
+import Data.Semigroup (Semigroup(..))
+
+fromLegacyAttr :: Attr -> B.Attr
+fromLegacyAttr (a, b, c) = (T.pack a, map T.pack b, map pack2 c)
+  where
+    pack2 (x, y) = (T.pack x, T.pack y)
+
+class ToMetaValue a where
+  toMetaValue :: a -> B.MetaValue
+
+instance ToMetaValue B.MetaValue where
+  toMetaValue = id
+
+instance ToMetaValue B.Blocks where
+  toMetaValue = B.MetaBlocks . B.toList
+
+instance ToMetaValue B.Inlines where
+  toMetaValue = MetaInlines . B.toList
+
+instance ToMetaValue Bool where
+  toMetaValue = MetaBool
+
+instance {-# OVERLAPPING #-} ToMetaValue String where
+  toMetaValue = MetaString
+
+instance ToMetaValue a => ToMetaValue [a] where
+  toMetaValue = MetaList . map toMetaValue
+
+instance ToMetaValue a => ToMetaValue (M.Map String a) where
+  toMetaValue = MetaMap . M.map toMetaValue
+
+class HasMeta a where
+  setMeta :: ToMetaValue b => String -> b -> a -> a
+  deleteMeta :: String -> a -> a
+
+instance HasMeta Meta where
+  setMeta key val (B.Meta ms) = B.Meta $ M.insert (T.pack key) (toMetaValue val) ms
+  deleteMeta key (B.Meta ms) = B.Meta $ M.delete (T.pack key) ms
+
+instance HasMeta Pandoc where
+  setMeta key val (Pandoc (B.Meta ms) bs) =
+    Pandoc (B.Meta $ M.insert (T.pack key) (toMetaValue val) ms) bs
+  deleteMeta key (Pandoc (B.Meta ms) bs) =
+    Pandoc (B.Meta $ M.delete (T.pack key) ms) bs
+
+text :: String -> B.Inlines
+text = B.text . T.pack
+
+str :: String -> B.Inlines
+str = B.str . T.pack
+
+codeWith :: Attr -> String -> B.Inlines
+codeWith a = B.codeWith (fromLegacyAttr a) . T.pack
+
+code :: String -> B.Inlines
+code = B.code . T.pack
+
+math :: String -> B.Inlines
+math = B.math . T.pack
+
+displayMath :: String -> B.Inlines
+displayMath = B.displayMath . T.pack
+
+rawInline :: String -> String -> B.Inlines
+rawInline s = B.rawInline (T.pack s) . T.pack
+
+link :: String -> String -> B.Inlines -> B.Inlines
+link s = B.link (T.pack s) . T.pack
+
+linkWith :: Attr -> String -> String -> B.Inlines -> B.Inlines
+linkWith a s = B.linkWith (fromLegacyAttr a) (T.pack s) . T.pack
+
+image :: String -> String -> B.Inlines -> B.Inlines
+image s = B.image (T.pack s) . T.pack
+
+imageWith :: Attr -> String -> String -> B.Inlines -> B.Inlines
+imageWith a s = B.imageWith (fromLegacyAttr a) (T.pack s) . T.pack
+
+spanWith :: Attr -> B.Inlines -> B.Inlines
+spanWith = B.spanWith . fromLegacyAttr
+
+codeBlockWith :: Attr -> String -> B.Blocks
+codeBlockWith a = B.codeBlockWith (fromLegacyAttr a) . T.pack
+
+codeBlock :: String -> B.Blocks
+codeBlock = B.codeBlock . T.pack
+
+rawBlock :: String -> String -> B.Blocks
+rawBlock s = B.rawBlock (T.pack s) . T.pack
+
+headerWith :: Attr -> Int -> B.Inlines -> B.Blocks
+headerWith = B.headerWith . fromLegacyAttr
+
+divWith :: Attr -> B.Blocks -> B.Blocks
+divWith = B.divWith . fromLegacyAttr

--- a/Text/Pandoc/Legacy/Definition.hs
+++ b/Text/Pandoc/Legacy/Definition.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE PatternSynonyms, ViewPatterns #-}
+
+module Text.Pandoc.Legacy.Definition
+  ( D.Pandoc(..)
+  , D.Meta
+  , pattern Meta
+  , unMeta
+  , D.MetaValue ( D.MetaList
+                , D.MetaBool
+                , D.MetaInlines
+                , D.MetaBlocks
+                )
+  , pattern MetaMap
+  , pattern MetaString
+  , D.nullMeta
+  , D.isNullMeta
+  , lookupMeta
+  , D.docTitle
+  , D.docAuthors
+  , D.docDate
+  , D.Block ( D.Plain
+            , D.Para
+            , D.LineBlock
+            , D.BlockQuote
+            , D.OrderedList
+            , D.BulletList
+            , D.DefinitionList
+            , D.HorizontalRule
+            , D.Table
+            , D.Null
+            )
+  , pattern CodeBlock
+  , pattern RawBlock
+  , pattern Header
+  , pattern Div
+  , D.Inline ( D.Emph
+             , D.Strong
+             , D.Strikeout
+             , D.Superscript
+             , D.Subscript
+             , D.SmallCaps
+             , D.Quoted
+             , D.Cite
+             , D.Space
+             , D.SoftBreak
+             , D.LineBreak
+             , D.Note
+             )
+  , pattern Str
+  , pattern Code
+  , pattern Math
+  , pattern RawInline
+  , pattern Link
+  , pattern Image
+  , pattern Span
+  , D.Alignment(..)
+  , D.ListAttributes
+  , D.ListNumberStyle(..)
+  , D.ListNumberDelim(..)
+  , D.Format
+  , pattern Format
+  , Attr
+  , nullAttr
+  , D.TableCell
+  , D.QuoteType(..)
+  , Target
+  , D.MathType(..)
+  , D.Citation
+  , pattern Citation
+  , citationId
+  , citationPrefix
+  , citationSuffix
+  , citationMode
+  , citationNoteNum
+  , citationHash
+  , D.CitationMode(..)
+  , D.pandocTypesVersion
+  ) where
+
+import qualified Text.Pandoc.Definition as D
+import qualified Data.Map as M
+import qualified Data.Text as T
+
+unpack2 :: (T.Text, T.Text) -> (String, String)
+unpack2 (x, y) = (T.unpack x, T.unpack y)
+
+pack2 :: (String, String) -> (T.Text, T.Text)
+pack2 (x, y) = (T.pack x, T.pack y)
+
+toLegacyMap :: M.Map T.Text a -> M.Map String a
+toLegacyMap = M.mapKeys T.unpack
+
+fromLegacyMap :: M.Map String a -> M.Map T.Text a
+fromLegacyMap = M.mapKeys T.pack
+
+toLegacyAttr :: D.Attr -> Attr
+toLegacyAttr (a, b, c) = (T.unpack a, map T.unpack b, map unpack2 c)
+
+fromLegacyAttr :: Attr -> D.Attr
+fromLegacyAttr (a, b, c) = (T.pack a, map T.pack b, map pack2 c)
+
+pattern Meta :: M.Map String D.MetaValue -> D.Meta
+pattern Meta {unMeta} <- D.Meta (toLegacyMap -> unMeta)
+  where
+    Meta = D.Meta . fromLegacyMap
+
+pattern MetaMap :: M.Map String D.MetaValue -> D.MetaValue
+pattern MetaMap x <- D.MetaMap (toLegacyMap -> x)
+  where
+    MetaMap = D.MetaMap . fromLegacyMap
+
+pattern MetaString :: String -> D.MetaValue
+pattern MetaString x <- D.MetaString (T.unpack -> x)
+  where
+    MetaString = D.MetaString . T.pack
+
+lookupMeta :: String -> D.Meta -> Maybe D.MetaValue
+lookupMeta = D.lookupMeta . T.pack
+
+pattern CodeBlock :: Attr -> String -> D.Block
+pattern CodeBlock a s <- D.CodeBlock (toLegacyAttr -> a) (T.unpack -> s)
+  where
+    CodeBlock a = D.CodeBlock (fromLegacyAttr a) . T.pack
+
+pattern RawBlock :: D.Format -> String -> D.Block
+pattern RawBlock f s <- D.RawBlock f (T.unpack -> s)
+  where
+    RawBlock f = D.RawBlock f . T.pack
+
+pattern Header :: Int -> Attr -> [D.Inline] -> D.Block
+pattern Header n a i <- D.Header n (toLegacyAttr -> a) i
+  where
+    Header n = D.Header n . fromLegacyAttr
+
+pattern Div :: Attr -> [D.Block] -> D.Block
+pattern Div a b <- D.Div (toLegacyAttr -> a) b
+  where
+    Div = D.Div . fromLegacyAttr
+
+pattern Str :: String -> D.Inline
+pattern Str s <- D.Str (T.unpack -> s)
+  where
+    Str = D.Str . T.pack
+
+pattern Code :: Attr -> String -> D.Inline
+pattern Code a s <- D.Code (toLegacyAttr -> a) (T.unpack -> s)
+  where
+    Code a = D.Code (fromLegacyAttr a) . T.pack
+
+pattern Math :: D.MathType -> String -> D.Inline
+pattern Math m s <- D.Math m (T.unpack -> s)
+  where
+    Math m = D.Math m . T.pack
+
+pattern RawInline :: D.Format -> String -> D.Inline
+pattern RawInline f s <- D.RawInline f (T.unpack -> s)
+  where
+    RawInline f = D.RawInline f . T.pack
+
+pattern Link :: Attr -> [D.Inline] -> Target -> D.Inline
+pattern Link a i t <- D.Link (toLegacyAttr -> a) i (unpack2 -> t)
+  where
+    Link a i = D.Link (fromLegacyAttr a) i . pack2
+
+pattern Image :: Attr -> [D.Inline] -> Target -> D.Inline
+pattern Image a i t <- D.Image (toLegacyAttr -> a) i (unpack2 -> t)
+  where
+    Image a i = D.Image (fromLegacyAttr a) i . pack2
+
+pattern Span :: Attr -> [D.Inline] -> D.Inline
+pattern Span a i <- D.Span (toLegacyAttr -> a) i
+  where
+    Span = D.Span . fromLegacyAttr
+
+pattern Format :: String -> D.Format
+pattern Format x <- D.Format (T.unpack -> x)
+  where
+    Format x = D.Format $ T.pack x
+
+type Attr = (String, [String], [(String, String)])
+
+nullAttr :: Attr
+nullAttr = ("", [], [])
+
+type Target = (String, String)
+
+pattern Citation
+  :: String
+  -> [D.Inline]
+  -> [D.Inline]
+  -> D.CitationMode
+  -> Int
+  -> Int
+  -> D.Citation
+pattern Citation
+  { citationId
+  , citationPrefix
+  , citationSuffix
+  , citationMode
+  , citationNoteNum
+  , citationHash } <- D.Citation (T.unpack -> citationId)
+                                 citationPrefix
+                                 citationSuffix
+                                 citationMode
+                                 citationNoteNum
+                                 citationHash
+  where
+    Citation = D.Citation . T.pack

--- a/benchmark/bench.hs
+++ b/benchmark/bench.hs
@@ -4,6 +4,7 @@ import Criterion.Main (bench, defaultMain, nf)
 import Text.Pandoc.Definition (Pandoc, Inline (Str))
 import Text.Pandoc.Walk (walk)
 import Text.Pandoc.Builder
+import qualified Data.Text as T
 
 main :: IO ()
 main =
@@ -14,16 +15,16 @@ main =
     ]
 
 prependZeroWidthSpace :: Inline -> Inline
-prependZeroWidthSpace (Str s) = Str ('\8203' : s)
+prependZeroWidthSpace (Str s) = Str (T.cons '\8203' s)
 prependZeroWidthSpace x = x
 
 prependZeroWidthSpace' :: Inline -> [Inline]
-prependZeroWidthSpace' (Str s) = [Str ('\8203' : s)]
+prependZeroWidthSpace' (Str s) = [Str (T.cons '\8203' s)]
 prependZeroWidthSpace' x = [x]
 
 prependZeroWidthSpace'' :: [Inline] -> [Inline]
 prependZeroWidthSpace'' (Str s : xs) =
-  Str ('\8203' : s) : prependZeroWidthSpace'' xs
+  Str (T.cons '\8203' s) : prependZeroWidthSpace'' xs
 prependZeroWidthSpace'' (x : xs) =
   x : prependZeroWidthSpace'' xs
 prependZeroWidthSpace'' [] = []

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -49,6 +49,7 @@ Library
   Other-modules:     Paths_pandoc_types
   Build-depends:     base >= 4.5 && < 5,
                      containers >= 0.3,
+                     text,
                      deepseq >= 1.4.1 && < 1.5,
                      syb >= 0.1 && < 0.8,
                      ghc-prim >= 0.2,
@@ -69,6 +70,7 @@ test-suite test-pandoc-types
                        syb,
                        aeson >= 0.6.2 && < 1.5,
                        containers >= 0.3,
+                       text,
                        bytestring >= 0.9 && < 0.11,
                        test-framework >= 0.3 && < 0.9,
                        test-framework-hunit >= 0.2 && < 0.4,

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -86,5 +86,6 @@ benchmark benchmark-pandoc-types
   hs-source-dirs:  benchmark
   build-depends:   pandoc-types,
                    base >= 4.5 && < 5,
+                   text,
                    criterion >= 1.0 && < 1.6
   ghc-options:   -rtsopts -Wall -fno-warn-unused-do-bind -O2

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -46,6 +46,7 @@ Library
                      Text.Pandoc.Builder
                      Text.Pandoc.JSON
                      Text.Pandoc.Arbitrary
+                     Text.Pandoc.Legacy.Definition
   Other-modules:     Paths_pandoc_types
   Build-depends:     base >= 4.5 && < 5,
                      containers >= 0.3,

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -46,6 +46,7 @@ Library
                      Text.Pandoc.Builder
                      Text.Pandoc.JSON
                      Text.Pandoc.Arbitrary
+                     Text.Pandoc.Legacy.Builder
                      Text.Pandoc.Legacy.Definition
   Other-modules:     Paths_pandoc_types
   Build-depends:     base >= 4.5 && < 5,

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -7,7 +7,6 @@ import Text.Pandoc.Builder (singleton, plain, text, simpleTable)
 import Data.Generics
 import Data.List (tails)
 import Test.HUnit (Assertion, assertEqual, assertFailure)
-import Data.Char (toUpper)
 import Data.Aeson (FromJSON, ToJSON, encode, decode)
 import Test.Framework
 import Test.Framework.Providers.QuickCheck2 (testProperty)

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -13,6 +13,8 @@ import Test.Framework
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.Framework.Providers.HUnit (testCase)
 import qualified Data.Map as M
+import Data.Text (Text)
+import qualified Data.Text as T
 import Data.String.QQ
 import Data.ByteString.Lazy (ByteString)
 import qualified Data.Monoid as Monoid
@@ -37,7 +39,7 @@ p_queryList f d = everything mappend (mempty `mkQ` f) d ==
                   query (mconcat . map f . tails) d
 
 inlineTrans :: Inline -> Inline
-inlineTrans (Str xs) = Str $ map toUpper xs
+inlineTrans (Str xs) = Str $ T.toUpper xs
 inlineTrans (Emph xs) = Strong xs
 inlineTrans x = x
 
@@ -62,7 +64,7 @@ blocksTrans [BlockQuote xs] = xs
 blocksTrans [Div _ xs] = xs
 blocksTrans xs = xs
 
-inlineQuery :: Inline -> String
+inlineQuery :: Inline -> Text
 inlineQuery (Str xs) = xs
 inlineQuery _ = ""
 


### PR DESCRIPTION
In the projects [issue](https://github.com/jgm/pandoc/issues/5581) in the main pandoc repository, this change was mentioned as a possible enhancement. I thought that I should start here and submit this pull request for comment before moving on to the other packages.

There is one place where I was unsure: the new `text` dependency currently lacks a version bound. The functions that are needed existed in that package as early as `text-0.3`, but I was not sure if such a generous bound was appropriate.

The only observable difference in behaviour introduced by these changes relates to `Format`, whose instances now use the `Data.Text.toCaseFold` instead of `map Data.Char.toLower`. Both the former function and `Data.Text.toLower` behave differently than the latter function, and `Data.Text.toCaseFold` is mentioned in `Data.Text` as being intended for case-insensitive comparison, though it does differ a little more in behaviour than `Data.Text.toLower`. This should not affect any of the recognized `Format` names, unless there is an exotic `Format` name that I am unaware of.