### PR TITLE
Better tables

### DIFF
--- a/Text/Pandoc/Arbitrary.hs
+++ b/Text/Pandoc/Arbitrary.hs
@@ -248,7 +248,7 @@ arbBlock n = frequency $ [ (10, Plain <$> arbInlines (n-1))
 
 arbRow :: Int -> Int -> Gen Row
 arbRow cs n = do
-  hs <- choose (0 :: Int, max cs 0)
+  hs <- choose (0 :: Int, cs)
   Row <$> arbAttr
       <*> vectorOf (cs - hs) (arbCell n)
       <*> vectorOf hs (arbCell n)
@@ -283,11 +283,8 @@ instance Arbitrary Citation where
 
 instance Arbitrary Row where
   arbitrary = do
-    hs <- choose (0 :: Int, 2)
-    bs <- choose (0 :: Int, 4)
-    Row <$> arbAttr
-        <*> vectorOf hs arbitrary
-        <*> vectorOf bs arbitrary
+    w <- choose (1 :: Int, 4)
+    resize 3 $ arbRow w 2
   shrink (Row attr rh rb)
     = [Row attr' rh rb | attr' <- shrinkAttr attr] ++
       [Row attr rh' rb | rh' <- shrink rh] ++

--- a/Text/Pandoc/Arbitrary.hs
+++ b/Text/Pandoc/Arbitrary.hs
@@ -191,6 +191,7 @@ instance Arbitrary Block where
   shrink HorizontalRule = []
   shrink (Table attr capt specs rhw thead tbody tfoot) =
     -- TODO: shrink number of columns
+    -- TODO: update the row head span?
     -- Shrink number of head rows and head row contents
     [Table attr capt specs rhw thead' tbody tfoot | thead' <- shrinkRows thead] ++
     -- Shrink number of body rows and body row contents

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -484,10 +484,11 @@ table capt cellspecs headers rows = singleton $
   Table nullAttr
         (caption Nothing $ if isNull capt then mempty else para capt)
         cellspecs
+        0
         [sanitise headers]
         (map sanitise rows)
         []
-   where sanitise = Row nullAttr [] . map (Cell nullAttr Nothing 1 1 . toList) . pad mempty numcols
+   where sanitise = Row nullAttr . map (Cell nullAttr Nothing 1 1 . toList) . pad mempty numcols
          numcols = length cellspecs
          pad element upTo list = take upTo (list ++ repeat element)
 

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -161,6 +161,7 @@ module Text.Pandoc.Builder ( module Text.Pandoc.Definition
                            , horizontalRule
                            , table
                            , simpleTable
+                           , caption
                            , divWith
                            )
 where
@@ -481,7 +482,7 @@ table :: Inlines               -- ^ Caption
       -> Blocks
 table capt cellspecs headers rows = singleton $
   Table nullAttr
-        (caption Nothing $ para capt)
+        (caption Nothing $ if isNull capt then mempty else para capt)
         cellspecs
         [sanitise headers]
         (map sanitise rows)

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -476,7 +476,7 @@ horizontalRule = singleton HorizontalRule
 -- | Table builder. Rows and headers will be padded or truncated to the size of
 -- @cellspecs@
 table :: Inlines               -- ^ Caption
-      -> [(Alignment, ColWidth)] -- ^ Column alignments and fractional widths
+      -> [ColSpec] -- ^ Column alignments and fractional widths
       -> [Blocks]              -- ^ Headers
       -> [[Blocks]]            -- ^ Rows
       -> Blocks

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleInstances, MultiParamTypeClasses, DeriveDataTypeable,
     GeneralizedNewtypeDeriving, CPP, StandaloneDeriving, DeriveGeneric,
-    DeriveTraversable, OverloadedStrings #-}
+    DeriveTraversable, OverloadedStrings, PatternGuards #-}
 {-
 Copyright (C) 2010-2019 John MacFarlane
 
@@ -159,10 +159,23 @@ module Text.Pandoc.Builder ( module Text.Pandoc.Definition
                            , header
                            , headerWith
                            , horizontalRule
+                           , cell
+                           , simpleCell
+                           , emptyCell
+                           , cellWith
                            , table
                            , simpleTable
+                           , tableWith
                            , caption
+                           , simpleCaption
+                           , emptyCaption
                            , divWith
+                           -- * Table processing
+                           , normalizeTableHead
+                           , normalizeTableBody
+                           , normalizeTableFoot
+                           , placeRowSection
+                           , clipRows
                            )
 where
 import Text.Pandoc.Definition
@@ -473,39 +486,242 @@ headerWith attr level = singleton . Header level attr . toList
 horizontalRule :: Blocks
 horizontalRule = singleton HorizontalRule
 
--- | Table builder. Rows and headers will be padded or truncated to the size of
--- @cellspecs@
-table :: Inlines               -- ^ Caption
-      -> [ColSpec] -- ^ Column alignments and fractional widths
-      -> [Blocks]              -- ^ Headers
-      -> [[Blocks]]            -- ^ Rows
+cellWith :: Attr
+         -> Alignment
+         -> RowSpan
+         -> ColSpan
+         -> Blocks
+         -> Cell
+cellWith at a r c = Cell at a r c . toList
+
+cell :: Alignment
+     -> RowSpan
+     -> ColSpan
+     -> Blocks
+     -> Cell
+cell = cellWith nullAttr
+
+-- | A 1×1 cell with default alignment.
+simpleCell :: Blocks -> Cell
+simpleCell = cell AlignDefault 1 1
+
+-- | A 1×1 empty cell.
+emptyCell :: Cell
+emptyCell = simpleCell mempty
+
+-- | Table builder. Performs normalization with 'normalizeTableHead',
+-- 'normalizeTableBody', and 'normalizeTableFoot'. The number of table
+-- columns is given by the length of @['ColSpec']@.
+table :: Caption
+      -> [ColSpec]
+      -> TableHead
+      -> [TableBody]
+      -> TableFoot
       -> Blocks
-table capt cellspecs headers rows = singleton $
-  Table nullAttr
-        (caption Nothing $ plain capt)
-        cellspecs
-        (TableHead nullAttr [sanitise headers])
-        [TableBody nullAttr 0 [] $ map sanitise rows]
-        (TableFoot nullAttr [])
-   where sanitise = Row nullAttr .
-                    map (Cell nullAttr AlignDefault 1 1 . toList) .
-                    pad mempty numcols
-         numcols = length cellspecs
-         pad element upTo list = take upTo (list ++ repeat element)
+table = tableWith nullAttr
+
+tableWith :: Attr
+          -> Caption
+          -> [ColSpec]
+          -> TableHead
+          -> [TableBody]
+          -> TableFoot
+          -> Blocks
+tableWith attr capt specs th tbs tf
+  = singleton $ Table attr capt specs th' tbs' tf'
+  where
+    twidth = length specs
+    th'  = normalizeTableHead twidth th
+    tbs' = map (normalizeTableBody twidth) tbs
+    tf'  = normalizeTableFoot twidth tf
 
 -- | A simple table without a caption.
 simpleTable :: [Blocks]   -- ^ Headers
             -> [[Blocks]] -- ^ Rows
             -> Blocks
 simpleTable headers rows =
-  table mempty (replicate numcols defaults) headers rows
+  table emptyCaption (replicate numcols defaults) th [tb] tf
   where defaults = (AlignDefault, ColWidthDefault)
         numcols  = case headers:rows of
                         [] -> 0
                         xs -> maximum (map length xs)
+        toRow = Row nullAttr . map simpleCell
+        th = TableHead nullAttr [toRow headers]
+        tb = TableBody nullAttr 0 [] $ map toRow rows
+        tf = TableFoot nullAttr []
 
 caption :: Maybe ShortCaption -> Blocks -> Caption
 caption x = Caption x . toList
 
+simpleCaption :: Blocks -> Caption
+simpleCaption = caption Nothing
+
+emptyCaption :: Caption
+emptyCaption = simpleCaption mempty
+
 divWith :: Attr -> Blocks -> Blocks
 divWith attr = singleton . Div attr . toList
+
+-- | Normalize the 'TableHead' with 'clipRows' and 'placeRowSection'
+-- so that when placed on a grid with the given width and a height
+-- equal to the number of rows in the initial 'TableHead', there will
+-- be no empty spaces or overlapping cells, and the cells will not
+-- protrude beyond the grid.
+normalizeTableHead :: Int -> TableHead -> TableHead
+normalizeTableHead twidth (TableHead attr rows)
+  = TableHead attr $ normalizeHeaderSection twidth rows
+
+-- | Normalize the intermediate head and body section of a
+-- 'TableBody', as in 'normalizeTableHead', but additionally ensure
+-- that row head cells do not go beyond the row head.
+normalizeTableBody :: Int -> TableBody -> TableBody
+normalizeTableBody twidth (TableBody attr rhc th tb)
+  = TableBody attr rhc' (normBody th) (normBody tb)
+  where
+    rhc' = max 0 $ min (RowHeadColumns twidth) rhc
+    normBody = normalizeBodySection twidth rhc'
+
+-- | Normalize the 'TableFoot', as in 'normalizeTableHead'.
+normalizeTableFoot :: Int -> TableFoot -> TableFoot
+normalizeTableFoot twidth (TableFoot attr rows)
+  = TableFoot attr $ normalizeHeaderSection twidth rows
+
+normalizeHeaderSection :: Int -- ^ The desired width of the table
+                       -> [Row]
+                       -> [Row]
+normalizeHeaderSection twidth rows
+  = normalizeRows' (replicate twidth 1) $ clipRows rows
+  where
+    normalizeRows' oldHang (Row attr cells:rs)
+      = let (newHang, cells', _) = placeRowSection oldHang $ cells <> repeat emptyCell
+            rs' = normalizeRows' newHang rs
+        in Row attr cells' : rs'
+    normalizeRows' _ [] = []
+
+normalizeBodySection :: Int -- ^ The desired width of the table
+                     -> RowHeadColumns -- ^ The width of the row head,
+                                       -- between 0 and the table
+                                       -- width
+                     -> [Row]
+                     -> [Row]
+normalizeBodySection twidth (RowHeadColumns rhc) rows
+  = normalizeRows' (replicate rhc 1) (replicate rbc 1) $ clipRows rows
+  where
+    rbc = twidth - rhc
+
+    normalizeRows' headHang bodyHang (Row attr cells:rs)
+      = let (headHang', rowHead, cells') = placeRowSection headHang $ cells <> repeat emptyCell
+            (bodyHang', rowBody, _)      = placeRowSection bodyHang cells'
+            rs' = normalizeRows' headHang' bodyHang' rs
+        in Row attr (rowHead <> rowBody) : rs'
+    normalizeRows' _ _ [] = []
+
+-- | Normalize the given list of cells so that they fit on a single
+-- grid row. The 'RowSpan' values of the cells are assumed to be valid
+-- (clamped to lie between 1 and the remaining grid height). The cells
+-- in the list are also assumed to be able to fill the entire grid
+-- row. These conditions can be met by appending @repeat 'emptyCell'@
+-- to the @['Cell']@ list and using 'clipRows' on the entire table
+-- section beforehand.
+--
+-- Normalization follows the principle that cells are placed on a grid
+-- row in order, each at the first available grid position from the
+-- left, having their 'ColSpan' reduced if they would overlap with a
+-- previous cell, stopping once the row is filled. Only the dimensions
+-- of cells are changed, and only of those cells that fit on the row.
+--
+-- Possible overlap is detected using the given @['RowSpan']@, which
+-- is the "overhang" of the previous grid row, a list of the heights
+-- of cells that descend through the previous row, reckoned
+-- /only from the previous row/.
+-- Its length should be the width (number of columns) of the current
+-- grid row.
+--
+-- For example, the numbers in the following headerless grid table
+-- represent the overhang at each grid position for that table:
+--
+-- @
+--     1   1   1   1
+--   +---+---+---+---+
+--   | 1 | 2   2 | 3 |
+--   +---+       +   +
+--   | 1 | 1   1 | 2 |
+--   +---+---+---+   +
+--   | 1   1 | 1 | 1 |
+--   +---+---+---+---+
+-- @
+--
+-- In any table, the row before the first has an overhang of
+-- @replicate tableWidth 1@, since there are no cells to descend into
+-- the table from there.  The overhang of the first row in the example
+-- is @[1, 2, 2, 3]@.
+--
+-- So if after 'clipRows' the unnormalized second row of that example
+-- table were
+--
+-- > r = [("a", 1, 2),("b", 2, 3)] -- the cells displayed as (label, RowSpan, ColSpan) only
+--
+-- a correct invocation of 'placeRowSection' to normalize it would be
+--
+-- >>> placeRowSection [1, 2, 2, 3] $ r ++ repeat emptyCell
+-- ([1, 1, 1, 2], [("a", 1, 1)], [("b", 2, 3)] ++ repeat emptyCell) -- wouldn't stop printing, of course
+--
+-- and if the third row were only @[("c", 1, 2)]@, then the expression
+-- would be
+--
+-- >>> placeRowSection [1, 1, 1, 2] $ [("c", 1, 2)] ++ repeat emptyCell
+-- ([1, 1, 1, 1], [("c", 1, 2), emptyCell], repeat emptyCell)
+placeRowSection :: [RowSpan] -- ^ The overhang of the previous grid
+                             -- row
+                -> [Cell]    -- ^ The cells to lay on the grid row
+                -> ([RowSpan], [Cell], [Cell]) -- ^ The overhang of
+                                               -- the current grid
+                                               -- row, the normalized
+                                               -- cells that fit on
+                                               -- the current row, and
+                                               -- the remaining
+                                               -- unmodified cells
+placeRowSection oldHang cellStream
+  -- If the grid has overhang at our position, try to re-lay in
+  -- the next position.
+  | o:os <- oldHang
+  , o > 1 = let (newHang, newCell, cellStream') = placeRowSection os cellStream
+            in (o - 1 : newHang, newCell, cellStream')
+  -- Otherwise if there is any available width, place the cell and
+  -- continue.
+  | c:cellStream' <- cellStream
+  , (h, w) <- getDim c
+  , w' <- max 1 w
+  , (n, oldHang') <- dropAtMostWhile (== 1) (getColSpan w') oldHang
+  , n > 0
+  = let w'' = min (ColSpan n) w'
+        c' = setW w'' c
+        (newHang, newCell, remainCell) = placeRowSection oldHang' cellStream'
+    in (replicate (getColSpan w'') h <> newHang, c' : newCell, remainCell)
+  -- Otherwise there is no room in the section, or not enough cells
+  -- were given.
+  | otherwise = ([], [], cellStream)
+  where
+    getColSpan (ColSpan w) = w
+    getDim (Cell _ _ h w _) = (h, w)
+    setW w (Cell a ma h _ b) = Cell a ma h w b
+
+    dropAtMostWhile :: (a -> Bool) -> Int -> [a] -> (Int, [a])
+    dropAtMostWhile p n = go 0
+      where
+        go acc (l:ls) | p l && acc < n = go (acc+1) ls
+        go acc l = (acc, l)
+
+-- | Ensure that the height of each cell in a table section lies
+-- between 1 and the distance from its row to the end of the
+-- section. So if there were four rows in the input list, the cells in
+-- the second row would have their height clamped between 1 and 3.
+clipRows :: [Row] -> [Row]
+clipRows rows
+  = let totalHeight = RowSpan $ length rows
+    in map clipRowH $ zip [totalHeight, totalHeight - 1..1] rows
+  where
+    getH (Cell _ _ h _ _) = h
+    setH h (Cell a ma _ w body) = Cell a ma h w body
+    clipH low high c = let h = getH c in setH (min high $ max low h) c
+    clipRowH (high, Row attr cells) = Row attr $ map (clipH 1 high) cells

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -546,7 +546,10 @@ simpleTable headers rows =
                         [] -> 0
                         xs -> maximum (map length xs)
         toRow = Row nullAttr . map simpleCell
-        th = TableHead nullAttr [toRow headers]
+        toHeaderRow l
+          | null l    = []
+          | otherwise = [toRow headers]
+        th = TableHead nullAttr (toHeaderRow headers)
         tb = TableBody nullAttr 0 [] $ map toRow rows
         tf = TableFoot nullAttr []
 

--- a/Text/Pandoc/Builder.hs
+++ b/Text/Pandoc/Builder.hs
@@ -482,13 +482,14 @@ table :: Inlines               -- ^ Caption
       -> Blocks
 table capt cellspecs headers rows = singleton $
   Table nullAttr
-        (caption Nothing $ if isNull capt then mempty else para capt)
+        (caption Nothing $ plain capt)
         cellspecs
-        0
-        [sanitise headers]
-        (map sanitise rows)
-        []
-   where sanitise = Row nullAttr . map (Cell nullAttr Nothing 1 1 . toList) . pad mempty numcols
+        (TableHead nullAttr [sanitise headers])
+        [TableBody nullAttr 0 [] $ map sanitise rows]
+        (TableFoot nullAttr [])
+   where sanitise = Row nullAttr .
+                    map (Cell nullAttr AlignDefault 1 1 . toList) .
+                    pad mempty numcols
          numcols = length cellspecs
          pad element upTo list = take upTo (list ++ repeat element)
 
@@ -498,13 +499,13 @@ simpleTable :: [Blocks]   -- ^ Headers
             -> Blocks
 simpleTable headers rows =
   table mempty (replicate numcols defaults) headers rows
-  where defaults = (AlignDefault, Nothing)
+  where defaults = (AlignDefault, ColWidthDefault)
         numcols  = case headers:rows of
                         [] -> 0
                         xs -> maximum (map length xs)
 
-caption :: Maybe Inlines -> Blocks -> Caption
-caption x = Caption (toList <$> x) . toList
+caption :: Maybe ShortCaption -> Blocks -> Caption
+caption x = Caption x . toList
 
 divWith :: Attr -> Blocks -> Blocks
 divWith attr = singleton . Div attr . toList

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -66,6 +66,7 @@ module Text.Pandoc.Definition ( Pandoc(..)
                               , Caption(..)
                               , Alignment(..)
                               , ColWidth
+                              , ColSpec
                               , Row(..)
                               , RowHead
                               , RowBody
@@ -221,6 +222,9 @@ data Alignment = AlignLeft
 -- default width.
 type ColWidth = Maybe Double
 
+-- | The specification for a single table column.
+type ColSpec = (Alignment, Maybe Double)
+
 -- | A table row
 data Row = Row Attr RowHead RowBody
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
@@ -291,7 +295,7 @@ data Block
     -- | Table, with attributes, caption, optional short caption,
     -- column alignments and widths (required), table head, table
     -- body, and table foot
-    | Table Attr Caption [(Alignment, ColWidth)] TableHead TableBody TableFoot
+    | Table Attr Caption [ColSpec] TableHead TableBody TableFoot
     -- | Generic block container with attributes
     | Div Attr [Block]
     -- | Nothing

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -74,7 +74,6 @@ module Text.Pandoc.Definition ( Pandoc(..)
                               , TableBody(..)
                               , TableFoot(..)
                               , Cell(..)
-                              , emptyCell
                               , RowSpan(..)
                               , ColSpan(..)
                               , QuoteType(..)
@@ -258,10 +257,6 @@ data Caption = Caption (Maybe ShortCaption) [Block]
 -- | A table cell.
 data Cell = Cell Attr Alignment RowSpan ColSpan [Block]
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
-
--- | A 1×1 empty cell.
-emptyCell :: Cell
-emptyCell = Cell nullAttr AlignDefault 1 1 []
 
 -- | The number of rows occupied by a cell; the height of a cell.
 newtype RowSpan = RowSpan Int

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -57,14 +57,25 @@ module Text.Pandoc.Definition ( Pandoc(..)
                               , docDate
                               , Block(..)
                               , Inline(..)
-                              , Alignment(..)
                               , ListAttributes
                               , ListNumberStyle(..)
                               , ListNumberDelim(..)
                               , Format(..)
                               , Attr
                               , nullAttr
-                              , TableCell
+                              , Caption(..)
+                              , Alignment(..)
+                              , ColWidth
+                              , Row(..)
+                              , RowHead
+                              , RowBody
+                              , TableHead
+                              , TableBody
+                              , TableFoot
+                              , Cell(..)
+                              , emptyCell
+                              , RowSpan
+                              , ColSpan
                               , QuoteType(..)
                               , Target
                               , MathType(..)
@@ -162,12 +173,6 @@ docDate meta =
          Just (MetaBlocks [Para ils])  -> ils
          _                             -> []
 
--- | Alignment of a table column.
-data Alignment = AlignLeft
-               | AlignRight
-               | AlignCenter
-               | AlignDefault deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
-
 -- | List attributes.  The first element of the triple is the
 -- start number of the list.
 type ListAttributes = (Int, ListNumberStyle, ListNumberDelim)
@@ -193,9 +198,6 @@ type Attr = (Text, [Text], [(Text, Text)])
 nullAttr :: Attr
 nullAttr = ("",[],[])
 
--- | Table cells are list of Blocks
-type TableCell = [Block]
-
 -- | Formats for raw blocks
 newtype Format = Format Text
                deriving (Read, Show, Typeable, Data, Generic, ToJSON, FromJSON)
@@ -209,31 +211,91 @@ instance Eq Format where
 instance Ord Format where
   compare (Format x) (Format y) = compare (T.toCaseFold x) (T.toCaseFold y)
 
+-- | Alignment of a table column.
+data Alignment = AlignLeft
+               | AlignRight
+               | AlignCenter
+               | AlignDefault deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
+
+-- | The relative width of a column. A @Nothing@ value represents the
+-- default width.
+type ColWidth = Maybe Double
+
+-- | A table row
+data Row = Row Attr RowHead RowBody
+  deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
+
+-- | The header section of a table row.
+type RowHead = [Cell]
+
+-- | The body of a table row.
+type RowBody = [Cell]
+
+-- | The head of a table.
+type TableHead = [Row]
+
+-- | The body of a table.
+type TableBody = [Row]
+
+-- | The foot of a table.
+type TableFoot = [Row]
+
+-- | The caption of a table, with an optional short caption for
+-- inclusion in a list of figures.
+data Caption = Caption (Maybe [Inline]) [Block]
+  deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
+
+-- | A table cell.
+data Cell = Cell Attr (Maybe Alignment) RowSpan ColSpan [Block]
+  deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
+
+-- | A 1×1 empty cell.
+emptyCell :: Cell
+emptyCell = Cell nullAttr Nothing 1 1 []
+
+-- | The number of positions in a row occupied by a cell; the width of
+-- a cell.
+type RowSpan = Int
+
+-- | The number of positions in a column occupied by a cell; the
+-- height of a cell.
+type ColSpan = Int
+
 -- | Block element.
 data Block
-    = Plain [Inline]        -- ^ Plain text, not a paragraph
-    | Para [Inline]         -- ^ Paragraph
-    | LineBlock [[Inline]]  -- ^ Multiple non-breaking lines
-    | CodeBlock Attr Text -- ^ Code block (literal) with attributes
-    | RawBlock Format Text -- ^ Raw block
-    | BlockQuote [Block]    -- ^ Block quote (list of blocks)
-    | OrderedList ListAttributes [[Block]] -- ^ Ordered list (attributes
-                            -- and a list of items, each a list of blocks)
-    | BulletList [[Block]]  -- ^ Bullet list (list of items, each
-                            -- a list of blocks)
-    | DefinitionList [([Inline],[[Block]])]  -- ^ Definition list
-                            -- Each list item is a pair consisting of a
-                            -- term (a list of inlines) and one or more
-                            -- definitions (each a list of blocks)
-    | Header Int Attr [Inline] -- ^ Header - level (integer) and text (inlines)
-    | HorizontalRule        -- ^ Horizontal rule
-    | Table [Inline] [Alignment] [Double] [TableCell] [[TableCell]]  -- ^ Table,
-                            -- with caption, column alignments (required),
-                            -- relative column widths (0 = default),
-                            -- column headers (each a list of blocks), and
-                            -- rows (each a list of lists of blocks)
-    | Div Attr [Block]      -- ^ Generic block container with attributes
-    | Null                  -- ^ Nothing
+    -- | Plain text, not a paragraph
+    = Plain [Inline]
+    -- | Paragraph
+    | Para [Inline]
+    -- | Multiple non-breaking lines
+    | LineBlock [[Inline]]
+    -- | Code block (literal) with attributes
+    | CodeBlock Attr Text
+    -- | Raw block
+    | RawBlock Format Text
+    -- | Block quote (list of blocks)
+    | BlockQuote [Block]
+    -- | Ordered list (attributes and a list of items, each a list of
+    -- blocks)
+    | OrderedList ListAttributes [[Block]]
+    -- | Bullet list (list of items, each a list of blocks)
+    | BulletList [[Block]]
+    -- | Definition list. Each list item is a pair consisting of a
+    -- term (a list of inlines) and one or more definitions (each a
+    -- list of blocks)
+    | DefinitionList [([Inline],[[Block]])]
+    -- | Header - level (integer) and text (inlines)
+    | Header Int Attr [Inline]
+    -- | Horizontal rule
+    | HorizontalRule
+    -- | Table, with attributes, caption, optional short caption,
+    -- column alignments and widths (required), table head, table
+    -- body, and table foot
+    | Table Attr Caption [(Alignment, ColWidth)] TableHead TableBody TableFoot
+    -- | Generic block container with attributes
+    | Div Attr [Block]
+    -- | Nothing
+    | Null
     deriving (Eq, Ord, Read, Show, Typeable, Data, Generic)
 
 -- | Type of quotation marks to use in Quoted inline.
@@ -282,6 +344,8 @@ instance Ord Citation where
 
 data CitationMode = AuthorInText | SuppressAuthor | NormalCitation
                     deriving (Show, Eq, Ord, Read, Typeable, Data, Generic)
+
+
 
 
 -- ToJSON/FromJSON instances. We do this by hand instead of deriving
@@ -450,6 +514,38 @@ instance ToJSON Alignment where
             AlignCenter  -> "AlignCenter"
             AlignDefault -> "AlignDefault"
 
+instance FromJSON Row where
+  parseJSON (Object v) = do
+    t <- v .: "t" :: Aeson.Parser Value
+    case t of
+      "Row" -> do (attr, hdr, body) <- v .: "c"
+                  return $ Row attr hdr body
+      _     -> mempty
+  parseJSON _ = mempty
+instance ToJSON Row where
+  toJSON (Row attr hdr body) = tagged "Row" (attr, hdr, body)
+
+instance FromJSON Caption where
+  parseJSON (Object v) = do
+    t <- v .: "t" :: Aeson.Parser Value
+    case t of
+      "Caption" -> do (mshort, body) <- v .: "c"
+                      return $ Caption mshort body
+      _     -> mempty
+  parseJSON _ = mempty
+instance ToJSON Caption where
+  toJSON (Caption mshort body) = tagged "Caption" (mshort, body)
+
+instance FromJSON Cell where
+  parseJSON (Object v) = do
+    t <- v .: "t" :: Aeson.Parser Value
+    case t of
+      "Cell" -> do (attr, malign, rs, cs, body) <- v .: "c"
+                   return $ Cell attr malign rs cs body
+      _     -> mempty
+  parseJSON _ = mempty
+instance ToJSON Cell where
+  toJSON (Cell attr malign rs cs body) = tagged "Cell" (attr, malign, rs, cs, body)
 
 instance FromJSON Inline where
   parseJSON (Object v) = do
@@ -525,8 +621,8 @@ instance FromJSON Block where
       "Header"         -> do (n, attr, ils) <- v .: "c"
                              return $ Header n attr ils
       "HorizontalRule" -> return HorizontalRule
-      "Table"          -> do (cpt, align, wdths, hdr, rows) <- v .: "c"
-                             return $ Table cpt align wdths hdr rows
+      "Table"          -> do (attr, cpt, align, hdr, body, foot) <- v .: "c"
+                             return $ Table attr cpt align hdr body foot
       "Div"            -> do (attr, blks) <- v .: "c"
                              return $ Div attr blks
       "Null"           -> return Null
@@ -544,8 +640,8 @@ instance ToJSON Block where
   toJSON (DefinitionList defs) = tagged "DefinitionList" defs
   toJSON (Header n attr ils) = tagged "Header" (n, attr, ils)
   toJSON HorizontalRule = taggedNoContent "HorizontalRule"
-  toJSON (Table caption aligns widths cells rows) =
-    tagged "Table" (caption, aligns, widths, cells, rows)
+  toJSON (Table attr caption aligns hd body foot) =
+    tagged "Table" (attr, caption, aligns, hd, body, foot)
   toJSON (Div attr blks) = tagged "Div" (attr, blks)
   toJSON Null = taggedNoContent "Null"
 
@@ -579,6 +675,9 @@ instance NFData MetaValue
 instance NFData Meta
 instance NFData Citation
 instance NFData Alignment
+instance NFData Cell
+instance NFData Row
+instance NFData Caption
 instance NFData Inline
 instance NFData MathType
 instance NFData Format

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -224,7 +224,8 @@ data Alignment = AlignLeft
                | AlignCenter
                | AlignDefault deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 
--- | The relative width of a column.
+-- | The width of a table column, as a fraction of the total table
+-- width.
 data ColWidth = ColWidth Double
               | ColWidthDefault deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -214,9 +214,8 @@ instance Ord Format where
 
 -- | The number of columns taken up by the row head of each row of a
 -- 'TableBody'. The row body takes up the remaining columns.
-newtype RowHeadColumns = RowHeadColumns
-  { getRowHeadColumns :: Int
-  } deriving (Eq, Ord, Show, Read, Typeable, Data, Generic, Num, Enum)
+newtype RowHeadColumns = RowHeadColumns Int
+  deriving (Eq, Ord, Show, Read, Typeable, Data, Generic, Num, Enum)
 
 -- | Alignment of a table column.
 data Alignment = AlignLeft
@@ -265,14 +264,12 @@ emptyCell :: Cell
 emptyCell = Cell nullAttr AlignDefault 1 1 []
 
 -- | The number of rows occupied by a cell; the height of a cell.
-newtype RowSpan = RowSpan
-  { getRowSpan :: Int
-  } deriving (Eq, Ord, Show, Read, Typeable, Data, Generic, Num, Enum)
+newtype RowSpan = RowSpan Int
+  deriving (Eq, Ord, Show, Read, Typeable, Data, Generic, Num, Enum)
 
 -- | The number of columns occupied by a cell; the width of a cell.
-newtype ColSpan = ColSpan
-  { getColSpan :: Int
-  } deriving (Eq, Ord, Show, Read, Typeable, Data, Generic, Num, Enum)
+newtype ColSpan = ColSpan Int
+  deriving (Eq, Ord, Show, Read, Typeable, Data, Generic, Num, Enum)
 
 -- | Block element.
 data Block

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -64,7 +64,7 @@ module Text.Pandoc.Definition ( Pandoc(..)
                               , Attr
                               , nullAttr
                               , Caption(..)
-                              , RowHeadSpan
+                              , RowHeadColumns
                               , Alignment(..)
                               , ColWidth
                               , ColSpec
@@ -213,7 +213,7 @@ instance Ord Format where
 
 -- | The width of the row head of each row of a table. The row body
 -- takes up the remaining table width.
-type RowHeadSpan = Int
+type RowHeadColumns = Int
 
 -- | Alignment of a table column.
 data Alignment = AlignLeft
@@ -229,7 +229,8 @@ type ColWidth = Maybe Double
 type ColSpec = (Alignment, Maybe Double)
 
 -- | A table row. The header cells of the row are determined by the
--- value of the 'RowHeadSpan' of the table.
+-- value of the 'RowHeadColumns' of the table and the ultimate
+-- placement of the table cells on the grid.
 data Row = Row Attr [Cell]
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 
@@ -290,7 +291,7 @@ data Block
     -- | Table, with attributes, caption, optional short caption,
     -- column alignments and widths (required), table head, table
     -- body, and table foot
-    | Table Attr Caption [ColSpec] RowHeadSpan TableHead TableBody TableFoot
+    | Table Attr Caption [ColSpec] RowHeadColumns TableHead TableBody TableFoot
     -- | Generic block container with attributes
     | Div Attr [Block]
     -- | Nothing

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -244,8 +244,7 @@ type TableBody = [Row]
 -- | The foot of a table.
 type TableFoot = [Row]
 
--- | The caption of a table, with an optional short caption for
--- inclusion in a list of figures.
+-- | The caption of a table, with an optional short caption.
 data Caption = Caption (Maybe [Inline]) [Block]
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 
@@ -257,12 +256,10 @@ data Cell = Cell Attr (Maybe Alignment) RowSpan ColSpan [Block]
 emptyCell :: Cell
 emptyCell = Cell nullAttr Nothing 1 1 []
 
--- | The number of positions in a row occupied by a cell; the width of
--- a cell.
+-- | The number of rows occupied by a cell; the height of a cell.
 type RowSpan = Int
 
--- | The number of positions in a column occupied by a cell; the
--- height of a cell.
+-- | The number of columns occupied by a cell; the width of a cell.
 type ColSpan = Int
 
 -- | Block element.

--- a/Text/Pandoc/Definition.hs
+++ b/Text/Pandoc/Definition.hs
@@ -347,8 +347,6 @@ data CitationMode = AuthorInText | SuppressAuthor | NormalCitation
                     deriving (Show, Eq, Ord, Read, Typeable, Data, Generic)
 
 
-
-
 -- ToJSON/FromJSON instances. We do this by hand instead of deriving
 -- from generics, so we can have more control over the format.
 

--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -76,12 +76,12 @@ headers in a document with regular paragraphs in ALL CAPS:
 'query' can be used, for example, to compile a list of URLs
 linked to in a document:
 
-> extractURL :: Inline -> [String]
+> extractURL :: Inline -> [Text]
 > extractURL (Link _ _ (u,_)) = [u]
 > extractURL (Image _ _ (u,_)) = [u]
 > extractURL _ = []
 >
-> extractURLs :: Pandoc -> [String]
+> extractURLs :: Pandoc -> [Text]
 > extractURLs = query extractURL
 -}
 
@@ -89,11 +89,17 @@ linked to in a document:
 module Text.Pandoc.Walk
   ( Walkable(..)
   , queryBlock
+  , queryCaption
+  , queryRow
+  , queryCell
   , queryCitation
   , queryInline
   , queryMetaValue
   , queryPandoc
   , walkBlockM
+  , walkCaptionM
+  , walkRowM
+  , walkCellM
   , walkCitationM
   , walkInlineM
   , walkMetaValueM
@@ -485,7 +491,7 @@ queryRow :: (Walkable a Cell, Monoid c)
 queryRow f (Row _ hd bd) = query f hd <> query f bd
 
 -- | Helper method to walk the elements nested below 'Cell'
--- nodes. Only the @'[Block]'@ cell content is changed by this
+-- nodes. Only the @['Block']@ cell content is changed by this
 -- operation.
 walkCellM :: (Walkable a [Block], Monad m)
           => (a -> m a) -> Cell -> m Cell

--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -91,6 +91,9 @@ module Text.Pandoc.Walk
   , queryBlock
   , queryCaption
   , queryRow
+  , queryTableHead
+  , queryTableBody
+  , queryTableFoot
   , queryCell
   , queryCitation
   , queryInline
@@ -99,6 +102,9 @@ module Text.Pandoc.Walk
   , walkBlockM
   , walkCaptionM
   , walkRowM
+  , walkTableHeadM
+  , walkTableBodyM
+  , walkTableFootM
   , walkCellM
   , walkCitationM
   , walkInlineM

--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -400,12 +400,12 @@ walkBlockM _ x@CodeBlock {}           = return x
 walkBlockM _ x@RawBlock {}            = return x
 walkBlockM _ HorizontalRule           = return HorizontalRule
 walkBlockM _ Null                     = return Null
-walkBlockM f (Table attr capt as hs bs fs)
+walkBlockM f (Table attr capt as rhw hs bs fs)
   = do capt' <- walkM f capt
        hs' <- walkM f hs
        bs' <- walkM f bs
        fs' <- walkM f fs
-       return $ Table attr capt' as hs' bs' fs'
+       return $ Table attr capt' as rhw hs' bs' fs'
 
 -- | Perform a query on elements nested below a @'Block'@ element by
 -- querying all directly nested lists of @Inline@s or @Block@s.
@@ -423,7 +423,7 @@ queryBlock f (BulletList cs)          = query f cs
 queryBlock f (DefinitionList xs)      = query f xs
 queryBlock f (Header _ _ xs)          = query f xs
 queryBlock _ HorizontalRule           = mempty
-queryBlock f (Table _ capt _ hs bs fs)
+queryBlock f (Table _ capt _ _ hs bs fs)
   = query f capt <>
     query f hs <>
     query f bs <>
@@ -481,14 +481,12 @@ queryCitation f (Citation _ pref suff _ _ _) = query f pref <> query f suff
 -- @'Attr'@ component is not changed by this operation.
 walkRowM :: (Walkable a Cell, Monad m)
          => (a -> m a) -> Row -> m Row
-walkRowM f (Row attr hd bd) = do hd' <- walkM f hd
-                                 bd' <- walkM f bd
-                                 return $ Row attr hd' bd'
+walkRowM f (Row attr bd) = Row attr <$> walkM f bd
 
 -- | Query the elements below a 'Row' element.
 queryRow :: (Walkable a Cell, Monoid c)
          => (a -> c) -> Row -> c
-queryRow f (Row _ hd bd) = query f hd <> query f bd
+queryRow f (Row _ bd) = query f bd
 
 -- | Helper method to walk the elements nested below 'Cell'
 -- nodes. Only the @['Block']@ cell content is changed by this

--- a/Text/Pandoc/Walk.hs
+++ b/Text/Pandoc/Walk.hs
@@ -269,6 +269,63 @@ instance Walkable [Block] Row where
   query = queryRow
 
 --
+-- Walk TableHead
+--
+instance Walkable Inline TableHead where
+  walkM = walkTableHeadM
+  query = queryTableHead
+
+instance Walkable [Inline] TableHead where
+  walkM = walkTableHeadM
+  query = queryTableHead
+
+instance Walkable Block TableHead where
+  walkM = walkTableHeadM
+  query = queryTableHead
+
+instance Walkable [Block] TableHead where
+  walkM = walkTableHeadM
+  query = queryTableHead
+
+--
+-- Walk TableBody
+--
+instance Walkable Inline TableBody where
+  walkM = walkTableBodyM
+  query = queryTableBody
+
+instance Walkable [Inline] TableBody where
+  walkM = walkTableBodyM
+  query = queryTableBody
+
+instance Walkable Block TableBody where
+  walkM = walkTableBodyM
+  query = queryTableBody
+
+instance Walkable [Block] TableBody where
+  walkM = walkTableBodyM
+  query = queryTableBody
+
+--
+-- Walk TableFoot
+--
+instance Walkable Inline TableFoot where
+  walkM = walkTableFootM
+  query = queryTableFoot
+
+instance Walkable [Inline] TableFoot where
+  walkM = walkTableFootM
+  query = queryTableFoot
+
+instance Walkable Block TableFoot where
+  walkM = walkTableFootM
+  query = queryTableFoot
+
+instance Walkable [Block] TableFoot where
+  walkM = walkTableFootM
+  query = queryTableFoot
+
+--
 -- Walk Caption
 --
 instance Walkable Inline Caption where
@@ -385,7 +442,8 @@ queryInline f (Span _ xs)     = query f xs
 -- block element may change. The element itself, i.e. its constructor, its @'Attr'@,
 -- and its raw text value, will remain unchanged.
 walkBlockM :: (Walkable a [Block], Walkable a [Inline], Walkable a Row,
-               Walkable a Caption, Monad m, Applicative m, Functor m)
+               Walkable a Caption, Walkable a TableHead, Walkable a TableBody,
+               Walkable a TableFoot, Monad m, Applicative m, Functor m)
            => (a -> m a) -> Block -> m Block
 walkBlockM f (Para xs)                = Para <$> walkM f xs
 walkBlockM f (Plain xs)               = Plain <$> walkM f xs
@@ -400,17 +458,18 @@ walkBlockM _ x@CodeBlock {}           = return x
 walkBlockM _ x@RawBlock {}            = return x
 walkBlockM _ HorizontalRule           = return HorizontalRule
 walkBlockM _ Null                     = return Null
-walkBlockM f (Table attr capt as rhw hs bs fs)
+walkBlockM f (Table attr capt as hs bs fs)
   = do capt' <- walkM f capt
        hs' <- walkM f hs
        bs' <- walkM f bs
        fs' <- walkM f fs
-       return $ Table attr capt' as rhw hs' bs' fs'
+       return $ Table attr capt' as hs' bs' fs'
 
 -- | Perform a query on elements nested below a @'Block'@ element by
 -- querying all directly nested lists of @Inline@s or @Block@s.
 queryBlock :: (Walkable a Citation, Walkable a [Block], Walkable a Row,
-               Walkable a Caption, Walkable a [Inline], Monoid c)
+               Walkable a Caption, Walkable a TableHead, Walkable a TableBody,
+               Walkable a TableFoot, Walkable a [Inline], Monoid c)
            => (a -> c) -> Block -> c
 queryBlock f (Para xs)                = query f xs
 queryBlock f (Plain xs)               = query f xs
@@ -423,7 +482,7 @@ queryBlock f (BulletList cs)          = query f cs
 queryBlock f (DefinitionList xs)      = query f xs
 queryBlock f (Header _ _ xs)          = query f xs
 queryBlock _ HorizontalRule           = mempty
-queryBlock f (Table _ capt _ _ hs bs fs)
+queryBlock f (Table _ capt _ hs bs fs)
   = query f capt <>
     query f hs <>
     query f bs <>
@@ -488,6 +547,40 @@ queryRow :: (Walkable a Cell, Monoid c)
          => (a -> c) -> Row -> c
 queryRow f (Row _ bd) = query f bd
 
+-- | Helper method to walk the elements nested below @'TableHead'@ nodes. The
+-- @'Attr'@ component is not changed by this operation.
+walkTableHeadM :: (Walkable a Row, Monad m)
+               => (a -> m a) -> TableHead -> m TableHead
+walkTableHeadM f (TableHead attr body) = TableHead attr <$> walkM f body
+
+-- | Query the elements below a 'TableHead' element.
+queryTableHead :: (Walkable a Row, Monoid c)
+               => (a -> c) -> TableHead -> c
+queryTableHead f (TableHead _ body) = query f body
+
+-- | Helper method to walk the elements nested below @'TableBody'@
+-- nodes. The @'Attr'@ and @'RowHeadColumns'@ components are not
+-- changed by this operation.
+walkTableBodyM :: (Walkable a Row, Monad m)
+               => (a -> m a) -> TableBody -> m TableBody
+walkTableBodyM f (TableBody attr rhc hd bd) = TableBody attr rhc <$> walkM f hd <*> walkM f bd
+
+-- | Query the elements below a 'TableBody' element.
+queryTableBody :: (Walkable a Row, Monoid c)
+               => (a -> c) -> TableBody -> c
+queryTableBody f (TableBody _ _ hd bd) = query f hd <> query f bd
+
+-- | Helper method to walk the elements nested below @'TableFoot'@ nodes. The
+-- @'Attr'@ component is not changed by this operation.
+walkTableFootM :: (Walkable a Row, Monad m)
+               => (a -> m a) -> TableFoot -> m TableFoot
+walkTableFootM f (TableFoot attr body) = TableFoot attr <$> walkM f body
+
+-- | Query the elements below a 'TableFoot' element.
+queryTableFoot :: (Walkable a Row, Monoid c)
+               => (a -> c) -> TableFoot -> c
+queryTableFoot f (TableFoot _ body) = query f body
+
 -- | Helper method to walk the elements nested below 'Cell'
 -- nodes. Only the @['Block']@ cell content is changed by this
 -- operation.
@@ -502,12 +595,12 @@ queryCell f (Cell _ _ _ _ content) = query f content
 
 -- | Helper method to walk the elements nested below 'Caption'
 -- nodes.
-walkCaptionM :: (Walkable a [Block], Walkable a [Inline], Monad m)
+walkCaptionM :: (Walkable a [Block], Walkable a [Inline], Monad m, Walkable a ShortCaption)
           => (a -> m a) -> Caption -> m Caption
 walkCaptionM f (Caption mshort body) = Caption <$> walkM f mshort <*> walkM f body
 
 -- | Query the elements below a 'Cell' element.
-queryCaption :: (Walkable a [Block], Walkable a [Inline], Monoid c)
+queryCaption :: (Walkable a [Block], Walkable a [Inline], Walkable a ShortCaption, Monoid c)
           => (a -> c) -> Caption -> c
 queryCaption f (Caption mshort body) = query f mshort <> query f body
 

--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -46,8 +46,6 @@ Library
                      Text.Pandoc.Builder
                      Text.Pandoc.JSON
                      Text.Pandoc.Arbitrary
-                     Text.Pandoc.Legacy.Builder
-                     Text.Pandoc.Legacy.Definition
   Other-modules:     Paths_pandoc_types
   Build-depends:     base >= 4.5 && < 5,
                      containers >= 0.3,

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -330,19 +330,26 @@ t_table = ( Table
                    ,Str "table"
                    ,Space
                    ,Str "syntax."]])
-            [(AlignDefault,Nothing)
-            ,(AlignRight,Nothing)
-            ,(AlignLeft,Nothing)
-            ,(AlignCenter,Nothing)
-            ,(AlignDefault,Nothing)]
-            1 
-            [tRow 
+            [(AlignDefault,ColWidthDefault)
+            ,(AlignRight,ColWidthDefault)
+            ,(AlignLeft,ColWidthDefault)
+            ,(AlignCenter,ColWidthDefault)
+            ,(AlignDefault,ColWidthDefault)]
+            (TableHead ("idh", ["klsh"], [("k1h", "v1h"), ("k2h", "v2h")])
+             [tRow
               [tCell [Str "Head"]
               ,tCell [Str "Right"]
               ,tCell [Str "Left"]
               ,tCell [Str "Center"]
-              ,tCell [Str "Default"]]]
-            [tRow
+              ,tCell [Str "Default"]]])
+            [TableBody ("idb", ["klsb"], [("k1b", "v1b"), ("k2b", "v2b")]) 1
+             [tRow
+              [tCell [Str "ihead12"]
+              ,tCell [Str "i12"]
+              ,tCell [Str "i12"]
+              ,tCell [Str "i12"]
+              ,tCell [Str "i12"]]]
+             [tRow
               [tCell [Str "head12"]
               ,tCell' [Str "12"]
               ,tCell [Str "12"]
@@ -359,19 +366,19 @@ t_table = ( Table
               ,tCell [Str "1"]
               ,tCell [Str "1"]
               ,tCell [Str "1"]
-              ,tCell [Str "1"]]]
-            [tRow
+              ,tCell [Str "1"]]]]
+            (TableFoot ("idf", ["klsf"], [("k1f", "v1f"), ("k2f", "v2f")])
+             [tRow
               [tCell [Str "foot"]
               ,tCell [Str "footright"]
               ,tCell [Str "footleft"]
               ,tCell [Str "footcenter"]
-              ,tCell [Str "footdefault"]]]
-          ,
-            [s|{"t":"Table","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],{"t":"Caption","c":[[{"t":"Str","c":"short"}],[{"t":"Para","c":[{"t":"Str","c":"Demonstration"},{"t":"Space"},{"t":"Str","c":"of"},{"t":"Space"},{"t":"Str","c":"simple"},{"t":"Space"},{"t":"Str","c":"table"},{"t":"Space"},{"t":"Str","c":"syntax."}]}]]},[[{"t":"AlignDefault"},null],[{"t":"AlignRight"},null],[{"t":"AlignLeft"},null],[{"t":"AlignCenter"},null],[{"t":"AlignDefault"},null]],1,[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Head"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Right"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Left"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Center"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Default"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"foot"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footright"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footleft"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footcenter"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footdefault"}]}]]}]]}]]}|]
+              ,tCell [Str "footdefault"]]])
+          ,[s|{"t":"Table","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],{"t":"Caption","c":[[{"t":"Str","c":"short"}],[{"t":"Para","c":[{"t":"Str","c":"Demonstration"},{"t":"Space"},{"t":"Str","c":"of"},{"t":"Space"},{"t":"Str","c":"simple"},{"t":"Space"},{"t":"Str","c":"table"},{"t":"Space"},{"t":"Str","c":"syntax."}]}]]},[[{"t":"AlignDefault"},{"t":"ColWidthDefault"}],[{"t":"AlignRight"},{"t":"ColWidthDefault"}],[{"t":"AlignLeft"},{"t":"ColWidthDefault"}],[{"t":"AlignCenter"},{"t":"ColWidthDefault"}],[{"t":"AlignDefault"},{"t":"ColWidthDefault"}]],{"t":"TableHead","c":[["idh",["klsh"],[["k1h","v1h"],["k2h","v2h"]]],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"Head"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"Right"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"Left"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"Center"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"Default"}]}]]}]]}]]},[{"t":"TableBody","c":[["idb",["klsb"],[["k1b","v1b"],["k2b","v2b"]]],{"t":"RowHeadColumns","c":1},[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"ihead12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"i12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"i12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"i12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"i12"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"head12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"head123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"head1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]}]]}]]}],{"t":"TableFoot","c":[["idf",["klsf"],[["k1f","v1f"],["k2f","v2f"]]],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"foot"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"footright"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"footleft"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"footcenter"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},{"t":"RowSpan","c":1},{"t":"ColSpan","c":1},[{"t":"Plain","c":[{"t":"Str","c":"footdefault"}]}]]}]]}]]}]}|]
               )
   where
-    tCell i = Cell ("a", ["b"], [("c", "d"), ("e", "f")]) (Just AlignDefault) 1 1 [Plain i]
-    tCell' i = Cell ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) Nothing 1 1 [Plain i]
+    tCell i = Cell ("a", ["b"], [("c", "d"), ("e", "f")]) AlignDefault 1 1 [Plain i]
+    tCell' i = Cell ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) AlignDefault 1 1 [Plain i]
     tRow = Row ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])
 
 t_div :: (Block, ByteString)
@@ -394,21 +401,23 @@ t_tableSan = testCase "table sanitisation" assertion
                                   [plain (text "foo"), plain (text "bar")]
                                   [[mempty]
                                   ,[]]
-                   tCell i = Cell nullAttr Nothing 1 1 [Plain [Str i]]
+                   tCell i = Cell nullAttr AlignDefault 1 1 [Plain [Str i]]
                    emptyRow = Row nullAttr $ replicate 2 emptyCell
                    expected = singleton (Table
-                                         nullAttr
-                                         (Caption Nothing [])
-                                         [(AlignDefault,Nothing)
-                                         ,(AlignDefault,Nothing)]
-                                         0
-                                         [Row
                                           nullAttr
-                                          [tCell "foo"
-                                          ,tCell "bar"]]
-                                         [emptyRow
-                                         ,emptyRow]
-                                         [])
+                                          (Caption Nothing [])
+                                          [(AlignDefault,ColWidthDefault)
+                                          ,(AlignDefault,ColWidthDefault)]
+                                          (TableHead nullAttr
+                                           [Row nullAttr
+                                            [tCell "foo"
+                                            ,tCell "bar"]])
+                                          [TableBody nullAttr 0
+                                           []
+                                           [emptyRow
+                                           ,emptyRow]]
+                                         (TableFoot nullAttr
+                                          []))
 
 tests :: [Test]
 tests =

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -318,39 +318,60 @@ t_header = ( Header 2 ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) [Str "Head"]
 
 t_table :: (Block, ByteString)
 t_table = (  Table
-             [Str "Demonstration"
-             ,Space
-             ,Str "of"
-             ,Space
-             ,Str "simple"
-             ,Space
-             ,Str "table"
-             ,Space
-             ,Str "syntax."]
-             [AlignRight
-             ,AlignLeft
-             ,AlignCenter
-             ,AlignDefault]
-             [0.0,0.0,0.0,0.0]
-            [[Plain [Str "Right"]]
-            ,[Plain [Str "Left"]]
-            ,[Plain [Str "Center"]]
-            ,[Plain [Str "Default"]]]
-            [[[Plain [Str "12"]]
-             ,[Plain [Str "12"]]
-             ,[Plain [Str "12"]]
-             ,[Plain [Str "12"]]]
-            ,[[Plain [Str "123"]]
-             ,[Plain [Str "123"]]
-             ,[Plain [Str "123"]]
-             ,[Plain [Str "123"]]]
-            ,[[Plain [Str "1"]]
-             ,[Plain [Str "1"]]
-             ,[Plain [Str "1"]]
-             ,[Plain [Str "1"]]]]
+             ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])
+             (Caption
+              (Just [Str "short"])
+              [Para [Str "Demonstration"
+                    ,Space
+                    ,Str "of"
+                    ,Space
+                    ,Str "simple"
+                    ,Space
+                    ,Str "table"
+                    ,Space
+                    ,Str "syntax."]])
+             [(AlignDefault,Nothing)
+             ,(AlignRight,Nothing)
+             ,(AlignLeft,Nothing)
+             ,(AlignCenter,Nothing)
+             ,(AlignDefault,Nothing)]
+            [tRow 
+              [tCell [Str "Head"]]
+              [tCell [Str "Right"]
+              ,tCell [Str "Left"]
+              ,tCell [Str "Center"]
+              ,tCell [Str "Default"]]]
+            [tRow
+              [tCell [Str "head12"]]
+              [tCell' [Str "12"]
+              ,tCell [Str "12"]
+              ,tCell' [Str "12"]
+              ,tCell [Str "12"]]
+            ,tRow
+              [tCell [Str "head123"]]
+              [tCell [Str "123"]
+              ,tCell [Str "123"]
+              ,tCell [Str "123"]
+              ,tCell [Str "123"]]
+            ,tRow
+              [tCell [Str "head1"]]
+              [tCell [Str "1"]
+              ,tCell [Str "1"]
+              ,tCell [Str "1"]
+              ,tCell [Str "1"]]]
+            [tRow
+              [tCell [Str "foot"]]
+              [tCell [Str "footright"]
+              ,tCell [Str "footleft"]
+              ,tCell [Str "footcenter"]
+              ,tCell [Str "footdefault"]]]
           ,
-            [s|{"t":"Table","c":[[{"t":"Str","c":"Demonstration"},{"t":"Space"},{"t":"Str","c":"of"},{"t":"Space"},{"t":"Str","c":"simple"},{"t":"Space"},{"t":"Str","c":"table"},{"t":"Space"},{"t":"Str","c":"syntax."}],[{"t":"AlignRight"},{"t":"AlignLeft"},{"t":"AlignCenter"},{"t":"AlignDefault"}],[0,0,0,0],[[{"t":"Plain","c":[{"t":"Str","c":"Right"}]}],[{"t":"Plain","c":[{"t":"Str","c":"Left"}]}],[{"t":"Plain","c":[{"t":"Str","c":"Center"}]}],[{"t":"Plain","c":[{"t":"Str","c":"Default"}]}]],[[[{"t":"Plain","c":[{"t":"Str","c":"12"}]}],[{"t":"Plain","c":[{"t":"Str","c":"12"}]}],[{"t":"Plain","c":[{"t":"Str","c":"12"}]}],[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]],[[{"t":"Plain","c":[{"t":"Str","c":"123"}]}],[{"t":"Plain","c":[{"t":"Str","c":"123"}]}],[{"t":"Plain","c":[{"t":"Str","c":"123"}]}],[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]],[[{"t":"Plain","c":[{"t":"Str","c":"1"}]}],[{"t":"Plain","c":[{"t":"Str","c":"1"}]}],[{"t":"Plain","c":[{"t":"Str","c":"1"}]}],[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]]]}|]
+            [s|{"t":"Table","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],{"t":"Caption","c":[[{"t":"Str","c":"short"}],[{"t":"Para","c":[{"t":"Str","c":"Demonstration"},{"t":"Space"},{"t":"Str","c":"of"},{"t":"Space"},{"t":"Str","c":"simple"},{"t":"Space"},{"t":"Str","c":"table"},{"t":"Space"},{"t":"Str","c":"syntax."}]}]]},[[{"t":"AlignDefault"},null],[{"t":"AlignRight"},null],[{"t":"AlignLeft"},null],[{"t":"AlignCenter"},null],[{"t":"AlignDefault"},null]],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Head"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Right"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Left"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Center"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Default"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head12"}]}]]}],[{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head123"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head1"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"foot"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footright"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footleft"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footcenter"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footdefault"}]}]]}]]}]]}|]
               )
+  where
+    tCell i = Cell ("a", ["b"], [("c", "d"), ("e", "f")]) (Just AlignDefault) 1 1 [Plain i]
+    tCell' i = Cell ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) Nothing 1 1 [Plain i]
+    tRow = Row ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])
 
 t_div :: (Block, ByteString)
 t_div = ( Div ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) [Para [Str "Hello"]]
@@ -363,6 +384,7 @@ t_null = (Null, [s|{"t":"Null"}|])
 -- headers and rows are padded to a consistent number of
 -- cells in order to avoid syntax errors after conversion, see
 -- jgm/pandoc#4059.
+-- This may change as the table representation changes.
 t_tableSan :: Test
 t_tableSan = testCase "table sanitisation" assertion
              where assertion = assertEqual err expected generated
@@ -371,14 +393,21 @@ t_tableSan = testCase "table sanitisation" assertion
                                   [plain (text "foo"), plain (text "bar")]
                                   [[mempty]
                                   ,[]]
+                   tCell i = Cell nullAttr Nothing 1 1 [Plain [Str i]]
+                   emptyRow = Row nullAttr [] $ replicate 2 emptyCell
                    expected = singleton (Table
-                                         []
-                                         [AlignDefault, AlignDefault]
-                                         [0.0, 0.0]
-                                         [[Plain [Str "foo"]],
-                                          [Plain [Str "bar"]]]
-                                         [[[], []], [[], []]])
-
+                                         nullAttr
+                                         (Caption Nothing [])
+                                         [(AlignDefault,Nothing)
+                                         ,(AlignDefault,Nothing)]
+                                         [Row
+                                          nullAttr
+                                          []
+                                          [tCell "foo"
+                                          ,tCell "bar"]]
+                                         [emptyRow
+                                         ,emptyRow]
+                                         [])
 
 tests :: [Test]
 tests =

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -317,56 +317,57 @@ t_header = ( Header 2 ("id", ["kls"], [("k1", "v1"), ("k2", "v2")]) [Str "Head"]
            )
 
 t_table :: (Block, ByteString)
-t_table = (  Table
-             ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])
-             (Caption
-              (Just [Str "short"])
-              [Para [Str "Demonstration"
-                    ,Space
-                    ,Str "of"
-                    ,Space
-                    ,Str "simple"
-                    ,Space
-                    ,Str "table"
-                    ,Space
-                    ,Str "syntax."]])
-             [(AlignDefault,Nothing)
-             ,(AlignRight,Nothing)
-             ,(AlignLeft,Nothing)
-             ,(AlignCenter,Nothing)
-             ,(AlignDefault,Nothing)]
+t_table = ( Table
+            ("id", ["kls"], [("k1", "v1"), ("k2", "v2")])
+            (Caption
+             (Just [Str "short"])
+             [Para [Str "Demonstration"
+                   ,Space
+                   ,Str "of"
+                   ,Space
+                   ,Str "simple"
+                   ,Space
+                   ,Str "table"
+                   ,Space
+                   ,Str "syntax."]])
+            [(AlignDefault,Nothing)
+            ,(AlignRight,Nothing)
+            ,(AlignLeft,Nothing)
+            ,(AlignCenter,Nothing)
+            ,(AlignDefault,Nothing)]
+            1 
             [tRow 
-              [tCell [Str "Head"]]
-              [tCell [Str "Right"]
+              [tCell [Str "Head"]
+              ,tCell [Str "Right"]
               ,tCell [Str "Left"]
               ,tCell [Str "Center"]
               ,tCell [Str "Default"]]]
             [tRow
-              [tCell [Str "head12"]]
-              [tCell' [Str "12"]
+              [tCell [Str "head12"]
+              ,tCell' [Str "12"]
               ,tCell [Str "12"]
               ,tCell' [Str "12"]
               ,tCell [Str "12"]]
             ,tRow
-              [tCell [Str "head123"]]
-              [tCell [Str "123"]
+              [tCell [Str "head123"]
+              ,tCell [Str "123"]
               ,tCell [Str "123"]
               ,tCell [Str "123"]
               ,tCell [Str "123"]]
             ,tRow
-              [tCell [Str "head1"]]
-              [tCell [Str "1"]
+              [tCell [Str "head1"]
+              ,tCell [Str "1"]
               ,tCell [Str "1"]
               ,tCell [Str "1"]
               ,tCell [Str "1"]]]
             [tRow
-              [tCell [Str "foot"]]
-              [tCell [Str "footright"]
+              [tCell [Str "foot"]
+              ,tCell [Str "footright"]
               ,tCell [Str "footleft"]
               ,tCell [Str "footcenter"]
               ,tCell [Str "footdefault"]]]
           ,
-            [s|{"t":"Table","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],{"t":"Caption","c":[[{"t":"Str","c":"short"}],[{"t":"Para","c":[{"t":"Str","c":"Demonstration"},{"t":"Space"},{"t":"Str","c":"of"},{"t":"Space"},{"t":"Str","c":"simple"},{"t":"Space"},{"t":"Str","c":"table"},{"t":"Space"},{"t":"Str","c":"syntax."}]}]]},[[{"t":"AlignDefault"},null],[{"t":"AlignRight"},null],[{"t":"AlignLeft"},null],[{"t":"AlignCenter"},null],[{"t":"AlignDefault"},null]],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Head"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Right"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Left"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Center"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Default"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head12"}]}]]}],[{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head123"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head1"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"foot"}]}]]}],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footright"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footleft"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footcenter"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footdefault"}]}]]}]]}]]}|]
+            [s|{"t":"Table","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],{"t":"Caption","c":[[{"t":"Str","c":"short"}],[{"t":"Para","c":[{"t":"Str","c":"Demonstration"},{"t":"Space"},{"t":"Str","c":"of"},{"t":"Space"},{"t":"Str","c":"simple"},{"t":"Space"},{"t":"Str","c":"table"},{"t":"Space"},{"t":"Str","c":"syntax."}]}]]},[[{"t":"AlignDefault"},null],[{"t":"AlignRight"},null],[{"t":"AlignLeft"},null],[{"t":"AlignCenter"},null],[{"t":"AlignDefault"},null]],1,[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Head"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Right"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Left"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Center"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"Default"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],null,1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"12"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"123"}]}]]}]]},{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"head1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"1"}]}]]}]]}],[{"t":"Row","c":[["id",["kls"],[["k1","v1"],["k2","v2"]]],[{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"foot"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footright"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footleft"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footcenter"}]}]]},{"t":"Cell","c":[["a",["b"],[["c","d"],["e","f"]]],{"t":"AlignDefault"},1,1,[{"t":"Plain","c":[{"t":"Str","c":"footdefault"}]}]]}]]}]]}|]
               )
   where
     tCell i = Cell ("a", ["b"], [("c", "d"), ("e", "f")]) (Just AlignDefault) 1 1 [Plain i]
@@ -394,15 +395,15 @@ t_tableSan = testCase "table sanitisation" assertion
                                   [[mempty]
                                   ,[]]
                    tCell i = Cell nullAttr Nothing 1 1 [Plain [Str i]]
-                   emptyRow = Row nullAttr [] $ replicate 2 emptyCell
+                   emptyRow = Row nullAttr $ replicate 2 emptyCell
                    expected = singleton (Table
                                          nullAttr
                                          (Caption Nothing [])
                                          [(AlignDefault,Nothing)
                                          ,(AlignDefault,Nothing)]
+                                         0
                                          [Row
                                           nullAttr
-                                          []
                                           [tCell "foo"
                                           ,tCell "bar"]]
                                          [emptyRow

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -3,7 +3,9 @@
 import Text.Pandoc.Arbitrary ()
 import Text.Pandoc.Definition
 import Text.Pandoc.Walk
-import Text.Pandoc.Builder (singleton, plain, text, simpleTable)
+import Text.Pandoc.Builder (singleton, plain, text, simpleTable, table, emptyCell,
+                            normalizeTableHead, normalizeTableBody, normalizeTableFoot,
+                            emptyCaption)
 import Data.Generics
 import Data.List (tails)
 import Test.HUnit (Assertion, assertEqual, assertFailure)
@@ -11,6 +13,7 @@ import Data.Aeson (FromJSON, ToJSON, encode, decode)
 import Test.Framework
 import Test.Framework.Providers.QuickCheck2 (testProperty)
 import Test.Framework.Providers.HUnit (testCase)
+import Test.QuickCheck (forAll, choose, Property, Arbitrary, Testable)
 import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -419,6 +422,172 @@ t_tableSan = testCase "table sanitisation" assertion
                                          (TableFoot nullAttr
                                           []))
 
+withWidth :: Testable prop => (Int -> prop) -> Property
+withWidth = forAll $ choose (2 :: Int, 16)
+
+widthNormIsIdempotent :: (Arbitrary a, Show a, Eq a)
+                      => (Int -> a -> a) -> Property
+widthNormIsIdempotent f = withWidth $
+  \n a -> let a' = f n a in f n a' == a'
+
+p_tableNormHeadIdempotent :: Property
+p_tableNormHeadIdempotent = widthNormIsIdempotent normalizeTableHead
+
+p_tableNormBodyIdempotent :: Property
+p_tableNormBodyIdempotent = widthNormIsIdempotent normalizeTableBody
+
+p_tableNormFootIdempotent :: Property
+p_tableNormFootIdempotent = widthNormIsIdempotent normalizeTableFoot
+
+cellSubset :: Cell -> Cell -> Bool
+cellSubset (Cell attr1 align1 rs1 cs1 body1) (Cell attr2 align2 rs2 cs2 body2)
+  = and [ attr1 == attr2
+        , align1 == align2
+        , dimValid rs1 rs2
+        , dimValid cs1 cs2
+        , body1 == body2 ]
+  where
+    dimValid x y = (y < 1 && x == 1) || (x >= 1 && x <= y)
+
+-- True when the first list is an initial segment of the second,
+-- modulo cell subsetting and the appending of padding cells onto the
+-- second.
+cellsSubsetPad :: [Cell] -> [Cell] -> Bool
+cellsSubsetPad (x:xs) (y:ys) = cellSubset x y && cellsSubsetPad xs ys
+cellsSubsetPad xs _ = all isPadCell xs
+  where
+    isPadCell = (== emptyCell)
+
+-- Only valid for the TableHead and TableFoot. See also
+-- p_tableNormBodyIsSubset.
+rowSubset :: Row -> Row -> Bool
+rowSubset (Row a1 x1) (Row a2 x2) = a1 == a2 && cellsSubsetPad x1 x2
+
+normIsSubset :: (Arbitrary a, Show a, Eq a)
+             => (Int -> a -> a)
+             -> (a -> [Row])
+             -> Property
+normIsSubset f proj = withWidth $
+  \n a -> let a' = f n a in proj a' `rowsSubset` proj a
+  where
+    rowsSubset (x:xs) (y:ys) = rowSubset x y && rowsSubset xs ys
+    rowsSubset []     _      = True
+    rowsSubset (_:_)  []     = False
+
+p_tableNormHeadIsSubset :: Property
+p_tableNormHeadIsSubset = normIsSubset normalizeTableHead thproj
+  where
+    thproj (TableHead _ r) = r
+
+-- Checking that each row is a subset of its unnormalized version is a
+-- little onerous in the TableBody (because of the row head/row body
+-- distinction), so we settle for testing it only for the first row.
+p_tableNormBodyIsSubset :: Property
+p_tableNormBodyIsSubset = withWidth $
+  \n tb -> checkBody n (normalizeTableBody n tb) tb
+  where
+    cellLength (Cell _ _ _ (ColSpan w) _) = w
+    cellLengths = sum . map cellLength
+    gatherLen n = gatherLen' n 0
+    gatherLen' n count (c:cs) | count < n
+      = let (beg, end) = gatherLen' n (count + cellLength c) cs
+        in (c : beg, end)
+    gatherLen' _ _ cs = ([], cs)
+    -- Gather as much of the head as we can from the new and old rows,
+    -- then make sure the dimensions line up and the subsetting is
+    -- correct.
+    checkRow n rhc (Row _ r') (Row _ r)
+      = let (rhead', rbody') = gatherLen rhc r'
+            (rhead, rbody) = gatherLen rhc r
+        in and [ cellLengths rhead' == rhc
+               , rhc + cellLengths rbody' == n
+               , cellsSubsetPad rhead' rhead
+               , cellsSubsetPad rbody' rbody ]
+    checkRows n rhc (r':_) (r:_) = checkRow n rhc r' r
+    checkRows _ _   []     []    = True
+    checkRows _ _   _      _     = False
+    checkBody n (TableBody _ (RowHeadColumns rhc) th' tb') (TableBody _ _ th tb)
+      = checkRows n rhc th' th && checkRows n rhc tb' tb
+
+p_tableNormFootIsSubset :: Property
+p_tableNormFootIsSubset = normIsSubset normalizeTableFoot tfproj
+  where
+    tfproj (TableFoot _ r) = r
+
+-- True when the first row in a section (table head, table foot,
+-- intermediate header, body of table body) has the correct
+-- width. Only with the first row is it easy to check.
+firstRowCorrectWidth :: Int -> [Row] -> [Row] -> Bool
+firstRowCorrectWidth n (Row _ cs:_) (_:_) = n == sum (map cellLength cs)
+  where cellLength (Cell _ _ _ (ColSpan w) _) = w
+firstRowCorrectWidth _ []           []    = True
+firstRowCorrectWidth _ _            _     = False
+
+testRowCorrectWidth :: (Arbitrary a, Show a, Eq a)
+                     => (Int -> a -> a)
+                     -> (a -> [Row])
+                     -> Property
+testRowCorrectWidth f proj = withWidth $
+  \n a -> let a' = f n a in firstRowCorrectWidth n (proj a') (proj a)
+
+p_tableNormHeadRowWidth :: Property
+p_tableNormHeadRowWidth = testRowCorrectWidth normalizeTableHead thproj
+  where
+    thproj (TableHead _ r) = r
+
+p_tableNormBodyRowWidth :: Property
+p_tableNormBodyRowWidth = withWidth $
+  \n tb -> compBody n tb $ normalizeTableBody n tb
+  where
+    compBody n (TableBody _ _ th tb) (TableBody _ _ th' tb')
+      = firstRowCorrectWidth n th' th && firstRowCorrectWidth n tb' tb
+
+p_tableNormFootRowWidth :: Property
+p_tableNormFootRowWidth = testRowCorrectWidth normalizeTableFoot tfproj
+  where
+    tfproj (TableFoot _ r) = r
+
+t_tableNormExample :: Test
+t_tableNormExample = testCase "table normalization example" assertion
+  where
+    assertion = assertEqual "normalization error" expected generated
+    cl a h w = Cell (a, [], []) AlignDefault h w []
+    rws = map $ Row nullAttr
+    th = TableHead nullAttr . rws
+    tb n x y = TableBody nullAttr n (rws x) (rws y)
+    tf = TableFoot nullAttr . rws
+    initialHeads =
+      [[cl "a" 1 1,cl "b" 3 2]
+      ,[cl "c" 2 2           ,cl "d" 1 1]
+      ]
+    finalHeads =
+      [[cl "a" 1 1, cl "b" 2 2]
+      ,[cl "c" 1 1]
+      ]
+    initialTB = tb 1
+      [[cl "e" 4 3,cl "f" 4 3]
+      ,[]
+      ,[emptyCell]
+      ]
+      [[]
+      ,[cl "g" (-7) 0]]
+    finalTB = tb 1
+      [[cl "e" 3 1,cl "f" 3 2]
+      ,[]
+      ,[]
+      ]
+      [[emptyCell,emptyCell,emptyCell]
+      ,[cl "g" 1 1,emptyCell,emptyCell]
+      ]
+    spec = replicate 3 (AlignDefault, ColWidthDefault)
+    expected = singleton $ Table nullAttr
+                                 emptyCaption
+                                 spec
+                                 (th finalHeads)
+                                 [finalTB]
+                                 (tf finalHeads)
+    generated = table emptyCaption spec (th initialHeads) [initialTB] (tf initialHeads)
+
 tests :: [Test]
 tests =
   [ testGroup "Walk"
@@ -494,8 +663,20 @@ tests =
         , testEncodeDecode "Null" t_null
         ]
       ]
-    ],
-    t_tableSan
+    ]
+  , testGroup "Table normalization"
+    [ testProperty "p_tableNormHeadIdempotent" p_tableNormHeadIdempotent
+    , testProperty "p_tableNormBodyIdempotent" p_tableNormBodyIdempotent
+    , testProperty "p_tableNormFootIdempotent" p_tableNormFootIdempotent
+    , testProperty "p_tableNormHeadIsSubset" p_tableNormHeadIsSubset
+    , testProperty "p_tableNormBodyIsSubset" p_tableNormBodyIsSubset
+    , testProperty "p_tableNormFootIsSubset" p_tableNormFootIsSubset
+    , testProperty "p_tableNormHeadRowWidth" p_tableNormHeadRowWidth
+    , testProperty "p_tableNormBodyRowWidth" p_tableNormBodyRowWidth
+    , testProperty "p_tableNormFootRowWidth" p_tableNormFootRowWidth
+    ]
+  , t_tableSan
+  , t_tableNormExample
   ]
 
 


### PR DESCRIPTION
The initial implementation of issue #65. Other differences:

- The `Builder.table` and `Builder.simpleTable` have been adapted to the new type but have not had their signature or behaviour changed.
- The `Arbitrary` behaviour for tables is now different. Most notably, the instances do not produce normalized tables.
- The `Legacy.Definition` and `Legacy.Builder` modules are now not exposed. Would you like me to update them in some way, or remove them?
- There are `ToJSON` and `FromJSON` instances for `Row`, `Cell`, and `Caption`, all tagged. I checked the JSON output of the serialization test case and it seemed fine, so I updated the [expected bytestring](https://github.com/jgm/pandoc-types/compare/master...despresc:better-tables#diff-01f4ffe52cf097ab9ff89eebce394c86R369) in the test.
- `Walkable` instances for the new types have been added.

Once `pandoc` has been adapted to these changes, I can update this pull request with modified `table` and `simpleTable` builders. Incidentally, the behaviour of these (in particular `table`) should be pinned down. The `table` builder itself could be:
```haskell
table :: Caption
      -> [ColSpec]
      -> Rows
      -> Rows
      -> Rows
      -> Blocks
```
with `type Rows = Many Row` and a `row` and `cell` builder. Should the `table` builder normalize its output? If so, then I can put a table normalization function in `Builder` instead of somewhere in `pandoc`.