### PR TITLE
Change the table builder to permit looser intermediate table heads

### DIFF
--- a/src/Text/Pandoc/Builder.hs
+++ b/src/Text/Pandoc/Builder.hs
@@ -579,13 +579,16 @@ normalizeTableHead twidth (TableHead attr rows)
 
 -- | Normalize the intermediate head and body section of a
 -- 'TableBody', as in 'normalizeTableHead', but additionally ensure
--- that row head cells do not go beyond the row head.
+-- that row head cells do not go beyond the row head inside the
+-- intermediate body.
 normalizeTableBody :: Int -> TableBody -> TableBody
 normalizeTableBody twidth (TableBody attr rhc th tb)
-  = TableBody attr rhc' (normBody th) (normBody tb)
+  = TableBody attr
+              rhc'
+              (normalizeHeaderSection twidth th)
+              (normalizeBodySection twidth rhc' tb)
   where
     rhc' = max 0 $ min (RowHeadColumns twidth) rhc
-    normBody = normalizeBodySection twidth rhc'
 
 -- | Normalize the 'TableFoot', as in 'normalizeTableHead'.
 normalizeTableFoot :: Int -> TableFoot -> TableFoot

--- a/src/Text/Pandoc/Definition.hs
+++ b/src/Text/Pandoc/Definition.hs
@@ -238,8 +238,9 @@ data Row = Row Attr [Cell]
 data TableHead = TableHead Attr [Row]
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 
--- | A body of a table, with an intermediate head and the specified
--- number of row header columns.
+-- | A body of a table, with an intermediate head, intermediate body,
+-- and the specified number of row header columns in the intermediate
+-- body.
 data TableBody = TableBody Attr RowHeadColumns [Row] [Row]
   deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 


### PR DESCRIPTION
Right now the `table` builder enforces the `RowHeadColumns` boundary in the intermediate head of a `TableBody`. That means that a `TableBody` is currently supposed to look like

```
+-----------------------+--------------+
|  Head above row head  | Rest of head |
+-----------------------+--------------+
|        Row head       |    Row body  |
+-----------------------+--------------+
```

so if there were a cell in the top left whose width exceeded the `RowHeadColumns`, it would be shrunk to fit. I think this is a leftover of the original design of the new `Table` that had no intermediate tables at all; in that case the model above is actually how tables normally behave. But tables with intermediate sub-tables frequently have headings that stretch across the entire table (an [example](https://www.w3.org/WAI/tutorials/tables/multi-level/#table-with-three-headers-related-to-each-data-cell), which is encoded with two `tbody` elements). So what's done now is probably too aggressive.

This change makes the `TableBody` model look like

```
+---------------------+
|  Intermediate head  |
+----------+----------+
| Row head | Row body |
+----------+----------+
```

The only behavioural change is that `table` will not enforce the `RowHeadColumns` boundary in intermediate heads in a `TableBody`. It would still do that in the intermediate body, to ensure that the row head has a consistent column width.

This would mean that writers could not confidently put a vertical rule down the entire `TableBody`, but I'm not sure that any of them want that guarantee, especially compared to the more common case of wanting a table-width intermediate heading.