### PR TITLE
Fix incorrect table ColWidth documentation

### DIFF
--- a/src/Text/Pandoc/Definition.hs
+++ b/src/Text/Pandoc/Definition.hs
@@ -224,8 +224,7 @@ data Alignment = AlignLeft
                | AlignCenter
                | AlignDefault deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 
--- | The width of a table column, as a fraction of the total table
--- width.
+-- | The width of a table column, as a percentage of the text width.
 data ColWidth = ColWidth Double
               | ColWidthDefault deriving (Eq, Ord, Show, Read, Typeable, Data, Generic)
 


### PR DESCRIPTION
The documentation stated that the ColWidth represented the width
of the column as a fraction of the table width when in represents
a percentage of the page width.