### PR TITLE
Allow bytestring 0.11

### DIFF
--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -55,7 +55,7 @@ Library
                      deepseq >= 1.4.1 && < 1.5,
                      syb >= 0.1 && < 0.8,
                      ghc-prim >= 0.2,
-                     bytestring >= 0.9 && < 0.11,
+                     bytestring >= 0.9 && < 0.12,
                      aeson >= 0.6.2 && < 1.6,
                      transformers >= 0.2 && < 0.6,
                      QuickCheck >= 2.10 && < 2.15
@@ -74,7 +74,7 @@ test-suite test-pandoc-types
                        aeson >= 0.6.2 && < 1.6,
                        containers >= 0.3,
                        text,
-                       bytestring >= 0.9 && < 0.11,
+                       bytestring >= 0.9 && < 0.12,
                        test-framework >= 0.3 && < 0.9,
                        test-framework-hunit >= 0.2 && < 0.4,
                        test-framework-quickcheck2 >= 0.2.9 && < 0.4,


### PR DESCRIPTION
`cabal build --enable-tests --constrain 'bytestring == 0.11.1.0' && cabal test --enable-tests --constrain 'bytestring == 0.11.1.0'` passes.