### PR TITLE
Update ToJSONFilter docs: remove Meta, MetaValue

### DIFF
--- a/src/Text/Pandoc/JSON.hs
+++ b/src/Text/Pandoc/JSON.hs
@@ -86,7 +86,7 @@ import System.Environment (getArgs)
 -- to stdout.
 --
 -- For a straight transformation, use a function of type @a -> a@ or
--- @a -> IO a@ where @a@ = 'Block', 'Inline','Pandoc', 'Meta', or 'MetaValue'.
+-- @a -> IO a@ where @a@ = 'Block', 'Inline', or 'Pandoc'.
 --
 -- If your transformation needs to be sensitive to the script's arguments,
 -- use a function of type @[String] -> a -> a@ (with @a@ constrained as above).


### PR DESCRIPTION
Neither `Walkable Meta Pandoc` nor `Walkable MetaValue Pandoc` instances exist, so these types cannot be used with `ToJSONFilter`.

I grepped the source to check if there are any instances that I am not importing, and I did not find any.

I wrote a simple program to confirm that I am not missing something, and I indeed get errors for both types.

```haskell
{-# LANGUAGE TypeApplications #-}

module Main (main) where

import qualified Text.Pandoc.JSON as Pandoc

mainMeta :: IO ()
mainMeta = Pandoc.toJSONFilter $ id @Pandoc.Meta

mainMetaValue :: IO ()
mainMetaValue = Pandoc.toJSONFilter $ id @Pandoc.MetaValue

main :: IO ()
main = undefined
```

```
/path/to/Meta.hs:8:12: error:
    • No instance for (Text.Pandoc.Walk.Walkable
                         Pandoc.Meta Pandoc.Pandoc)
        arising from a use of ‘Pandoc.toJSONFilter’
    • In the expression: Pandoc.toJSONFilter $ id @Pandoc.Meta
      In an equation for ‘mainMeta’:
          mainMeta = Pandoc.toJSONFilter $ id @Pandoc.Meta
  |
8 | mainMeta = Pandoc.toJSONFilter $ id @Pandoc.Meta
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

/path/to/Meta.hs:11:17: error:
    • No instance for (Text.Pandoc.Walk.Walkable
                         Pandoc.MetaValue Pandoc.Pandoc)
        arising from a use of ‘Pandoc.toJSONFilter’
    • In the expression: Pandoc.toJSONFilter $ id @Pandoc.MetaValue
      In an equation for ‘mainMetaValue’:
          mainMetaValue = Pandoc.toJSONFilter $ id @Pandoc.MetaValue
   |
11 | mainMetaValue = Pandoc.toJSONFilter $ id @Pandoc.MetaValue
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```