### PR TITLE
Add Walkable Meta(Value) Pandoc instances

### DIFF
--- a/src/Text/Pandoc/JSON.hs
+++ b/src/Text/Pandoc/JSON.hs
@@ -86,7 +86,7 @@ import System.Environment (getArgs)
 -- to stdout.
 --
 -- For a straight transformation, use a function of type @a -> a@ or
--- @a -> IO a@ where @a@ = 'Block', 'Inline', or 'Pandoc'.
+-- @a -> IO a@ where @a@ = 'Block', 'Inline', 'Pandoc', 'Meta', or 'MetaValue'.
 --
 -- If your transformation needs to be sensitive to the script's arguments,
 -- use a function of type @[String] -> a -> a@ (with @a@ constrained as above).

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -67,6 +67,14 @@ blocksTrans [BlockQuote xs] = xs
 blocksTrans [Div _ xs] = xs
 blocksTrans xs = xs
 
+metaValueTrans :: MetaValue -> MetaValue
+metaValueTrans (MetaBool x) = MetaBool $ not x
+metaValueTrans (MetaString xs) = MetaString $ T.toUpper xs
+metaValueTrans x = x
+
+metaTrans :: Meta -> Meta
+metaTrans (Meta metamap) = Meta $ M.mapKeys T.toUpper metamap
+
 inlineQuery :: Inline -> Text
 inlineQuery (Str xs) = xs
 inlineQuery _ = ""
@@ -81,6 +89,12 @@ blockQuery _ = []
 blocksQuery :: [Block] -> Monoid.Sum Int
 blocksQuery = Monoid.Sum . length
 
+metaValueQuery :: MetaValue -> Text
+metaValueQuery (MetaString xs) = xs
+metaValueQuery _ = ""
+
+metaQuery :: Meta -> Monoid.Sum Int
+metaQuery (Meta metamap) = Monoid.Sum $ M.size metamap
 
 prop_roundtrip :: Pandoc -> Bool
 prop_roundtrip doc = case decode $ encode doc :: (Maybe Pandoc) of
@@ -659,8 +673,12 @@ tests =
   [ testGroup "Walk"
     [ testProperty "p_walk inlineTrans" (p_walk inlineTrans)
     , testProperty "p_walk blockTrans" (p_walk blockTrans)
+    , testProperty "p_walk metaValueTrans" (p_walk metaValueTrans)
+    , testProperty "p_walk metaTrans" (p_walk metaTrans)
     , testProperty "p_query inlineQuery" (p_query inlineQuery)
     , testProperty "p_query blockQuery" (p_query blockQuery)
+    , testProperty "p_query metaValueQuery" (p_query metaValueQuery)
+    , testProperty "p_query metaQuery" (p_query metaQuery)
     , testProperty "p_walkList inlinesTrans"  (p_walkList inlinesTrans)
     , testProperty "p_queryList inlinesQuery" (p_queryList inlinesQuery)
     , testProperty "p_walkList blocksTrans"  (p_walkList blocksTrans)


### PR DESCRIPTION
I implemented the following instances, allowing `ToJSONFilter` to work with `Meta` and `MetaValue`, as suggested in #95.

* `Walkable Meta Pandoc`
* `Walkable MetaValue Pandoc`

Notes:

* The `Walkable Meta Pandoc` instance does not need to recurse because `Meta` is only used in `Pandoc`.  There is no `[Meta]` instance because there is only a single `Meta` value.
* The `Walkable MetaValue Pandoc` instance makes use of new `Walkable MetaValue Meta` and `Walkable MetaValue MetaValue` instances.  These instance implementations map over containers directly; there is no `[MetaValue]` instance because `MetaValue` is also used as `Meta` and `MetaMap` map values.

Please let me know if there are any issues or formatting inconsistencies that you would like me to correct.  You are of course welcome to fix such things yourself if doing so requires less of your time.

Thank you!