### PR TITLE
RFC: add labels to display math equations

### DIFF
--- a/src/Text/Pandoc/Arbitrary.hs
+++ b/src/Text/Pandoc/Arbitrary.hs
@@ -342,10 +342,11 @@ instance Arbitrary Caption where
 
 instance Arbitrary MathType where
         arbitrary
-          = do x <- choose (0 :: Int, 1)
+          = do x <- choose (0 :: Int, 2)
                case x of
-                   0 -> return DisplayMath
-                   1 -> return InlineMath
+                   0 -> return (DisplayMath "")
+                   1 -> return (DisplayMath "1")
+                   2 -> return InlineMath
                    _ -> error "FATAL ERROR: Arbitrary instance, logic bug"
 
 instance Arbitrary QuoteType where

--- a/src/Text/Pandoc/Builder.hs
+++ b/src/Text/Pandoc/Builder.hs
@@ -138,6 +138,7 @@ module Text.Pandoc.Builder ( module Text.Pandoc.Definition
                            , linebreak
                            , math
                            , displayMath
+                           , labeledDisplayMath
                            , rawInline
                            , link
                            , linkWith
@@ -406,7 +407,11 @@ math = singleton . Math InlineMath
 
 -- | Display math
 displayMath :: Text -> Inlines
-displayMath = singleton . Math DisplayMath
+displayMath = singleton . Math (DisplayMath "")
+
+-- | Labeled display math
+labeledDisplayMath :: Text {-^ label -} -> Text {-^ math -} -> Inlines
+labeledDisplayMath label = singleton . Math (DisplayMath label)
 
 rawInline :: Text -> Text -> Inlines
 rawInline format = singleton . RawInline (Format format)

--- a/src/Text/Pandoc/Definition.hs
+++ b/src/Text/Pandoc/Definition.hs
@@ -342,7 +342,10 @@ pattern SimpleFigure attr figureCaption tgt <-
 
 
 -- | Type of math element (display or inline).
-data MathType = DisplayMath | InlineMath deriving (Show, Eq, Ord, Read, Typeable, Data, Generic)
+data MathType = DisplayMath Text  -- ^ Visually separated from other text;
+                                  -- has an (possibly empty) label
+              | InlineMath        -- ^ Math within the flow of a paragraph.
+  deriving (Show, Eq, Ord, Read, Typeable, Data, Generic)
 
 -- | Inline elements.
 data Inline

--- a/test/test-pandoc-types.hs
+++ b/test/test-pandoc-types.hs
@@ -163,7 +163,7 @@ t_citation = ( Citation { citationId = "jameson:unconscious",
              )
 
 t_displaymath :: (MathType, ByteString)
-t_displaymath = ( DisplayMath, [s|{"t":"DisplayMath"}|])
+t_displaymath = ( DisplayMath "1", [s|{"t":"DisplayMath","c":"1"}|])
 
 t_inlinemath :: (MathType, ByteString)
 t_inlinemath = ( InlineMath, [s|{"t":"InlineMath"}|])


### PR DESCRIPTION
It might make sense to somehow distinguish between no-label, automatic labels, and manual labels. The LaTeX generic equivalents to this would be the environments `equation*`, `equation`, and `equation` with an explicit `\tag`.

Counter point to this proposal: it would be difficult to represent in Markdown without resorting to raw LaTeX.

Is this something worth exploring further?