### PR TITLE
Remove string qq dependency

### DIFF
--- a/pandoc-types.cabal
+++ b/pandoc-types.cabal
@@ -69,6 +69,7 @@ test-suite test-pandoc-types
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             test-pandoc-types.hs
+  Other-modules:       Data.String.QQ
   build-depends:       base,
                        pandoc-types,
                        syb,
@@ -81,7 +82,7 @@ test-suite test-pandoc-types
                        test-framework-quickcheck2 >= 0.2.9 && < 0.4,
                        QuickCheck >= 2.10 && < 2.15,
                        HUnit >= 1.2 && < 1.7,
-                       string-qq >= 0.0.2 && < 0.1
+                       template-haskell >= 2
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -O2
   default-language:  Haskell2010
 

--- a/test/Data/String/QQ.hs
+++ b/test/Data/String/QQ.hs
@@ -1,0 +1,19 @@
+-- | This module is based off the QQ implementation from string-qq
+-- (https://github.com/audreyt/string-qq).
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE RankNTypes #-}
+module Data.String.QQ (s) where
+import Data.String (IsString(..))
+import Language.Haskell.TH.Quote (QuasiQuoter(..))
+
+s :: QuasiQuoter
+s = QuasiQuoter expr pat typ dec
+  where
+    expr = (\a -> [|fromString a|]) . clean
+    pat = error "Cannot use s as a pattern"
+    typ = error "Cannot use s as a type"
+    dec = error "Cannot use s as a dec"
+    clean = removeCarriageReturns . trimLeadingNewline
+    removeCarriageReturns = filter (/= '\r')
+    trimLeadingNewline ('\n':xs) = xs
+    trimLeadingNewline xs = xs

--- a/test/Data/String/QQ.hs
+++ b/test/Data/String/QQ.hs
@@ -1,6 +1,6 @@
 -- | This module is based off the QQ implementation from string-qq
 -- (https://github.com/audreyt/string-qq).
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE RankNTypes #-}
 module Data.String.QQ (s) where
 import Data.String (IsString(..))


### PR DESCRIPTION
This pull request replaces the dependency on the string-qq package with a compatible module. Depending on string-qq causes the transitive dependency graph to require `text >=1.2 && <1.3`. Removing this dependency will allow building with newer versions of `text` (tested with text-2.0.1). Given the very small size and limited use of `string-qq`, removing a dependency here seems like a win.